### PR TITLE
Add a Map in SlackAttachment to allow for fields not specified by dir…

### DIFF
--- a/src/main/java/com/ullink/slack/simpleslackapi/SlackAttachment.java
+++ b/src/main/java/com/ullink/slack/simpleslackapi/SlackAttachment.java
@@ -1,22 +1,26 @@
 package com.ullink.slack.simpleslackapi;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class SlackAttachment
 {
-    public String           title;
-    public String           titleLink;
-    public String           fallback;
-    public String           text;
-    public String           pretext;
-    public String           thumb_url;
+    public String              title;
+    public String              titleLink;
+    public String              fallback;
+    public String              text;
+    public String              pretext;
+    public String              thumb_url;
 
-    public String           color;
+    public String              color;
 
-    public List<SlackField> fields;
+    public Map<String, String> miscRootFields;
 
-    public List<String>     markdown_in;
+    public List<SlackField>    fields;
+
+    public List<String>        markdown_in;
 
     public SlackAttachment()
     {
@@ -52,6 +56,15 @@ public class SlackAttachment
             markdown_in = new ArrayList<>();
         }
         markdown_in.add(value);
+    }
+
+    public void addMiscField(String key, String value)
+    {
+        if (miscRootFields == null)
+        {
+            miscRootFields = new HashMap<>();
+        }
+        miscRootFields.put(key, value);
     }
 
     public void setTitle(String title)

--- a/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONAttachmentFormatter.java
+++ b/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONAttachmentFormatter.java
@@ -7,6 +7,7 @@ import org.json.simple.JSONObject;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 class SlackJSONAttachmentFormatter
 {
@@ -44,6 +45,13 @@ class SlackJSONAttachmentFormatter
             if (attachments[i].fallback != null)
             {
                 attachmentJSON.put("fallback", attachments[i].fallback);
+            }
+            if (attachments[i].miscRootFields != null)
+            {
+                for (Map.Entry<String, String> entry : attachments[i].miscRootFields.entrySet())
+                {
+                    attachmentJSON.put(entry.getKey(), entry.getValue());
+                }
             }
             if (attachments[i].markdown_in != null && !attachments[i].markdown_in.isEmpty())
             {


### PR DESCRIPTION
…ect fields.

This allows an easy way to add continued support for the countless fields Slack continues to add. See https://api.slack.com/docs/attachments