### PR TITLE
Use Integer rather than int for return type of getTimeZoneOffset()

### DIFF
--- a/src/main/java/com/ullink/slack/simpleslackapi/SlackPersona.java
+++ b/src/main/java/com/ullink/slack/simpleslackapi/SlackPersona.java
@@ -18,5 +18,5 @@ public interface SlackPersona
     boolean isBot();
     String getTimeZone();
     String getTimeZoneLabel();
-    int getTimeZoneOffset();
+    Integer getTimeZoneOffset();
 }

--- a/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackPersonaImpl.java
+++ b/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackPersonaImpl.java
@@ -116,7 +116,7 @@ class SlackPersonaImpl implements SlackPersona
     }
 
     @Override
-    public int getTimeZoneOffset()
+    public Integer getTimeZoneOffset()
     {
         return timeZoneOffset;
     }


### PR DESCRIPTION
The current mismatch in declared type (`Integer`) and returned type (`int`) results in Jackson throwing errors:

```
com.fasterxml.jackson.databind.JsonMappingException: (was java.lang.NullPointerException) (through reference chain: com.ullink.slack.simpleslackapi.impl.SlackMessagePostedImpl["channel"]->com.ullink.slack.simpleslackapi.impl.SlackChannelImpl["members"]->java.util.ArrayList[2]->com.ullink.slack.simpleslackapi.impl.SlackUserImpl["timeZoneOffset"])
	at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:210)
	at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:177)
	at com.fasterxml.jackson.databind.ser.std.StdSerializer.wrapAndThrow(StdSerializer.java:187)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:647)
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:152)
	at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serializeContents(IndexedListSerializer.java:100)
	at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serializeContents(IndexedListSerializer.java:21)
	at com.fasterxml.jackson.databind.ser.std.AsArraySerializerBase.serialize(AsArraySerializerBase.java:183)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:505)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:639)
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:152)
	at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:505)
	at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:639)
	at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:152)
	at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:128)
	at com.fasterkson.databind.ObjectMapper._configAndWriteValue(ObjectMapper.java:2881)
	at com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString(ObjectMapper.java:2338)
	at com.jstanier.slacktokafka.message.SlackMessageProcessor.process(SlackMessageProcessor.java:38)
	at com.jstanier.slacktokafka.message.SlackMessageHandler.onEvent(SlackMessageHandler.java:19)
	at com.jstanier.slacktokafka.message.SlackMessageHandler.onEvent(SlackMessageHandler.java:10)
	at com.ullink.slack.simpleslackapi.impl.SlackWebSocketSessionImpl$EventDispatcher.dispatchImpl(SlackWebSocketSessionImpl.java:107)
...
```

This can happen when there is a deleted user in a Slack channel. A deleted user has `timeZoneOffset` set to `null`.