### PR TITLE
Add the option to turn off link unfurling

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Many thanks to everyone who has contributed to this library :
 * Ole Kozaczenko
 * Georges Gomes
 * François Valdy
+* Harry Fox
 
 (Let me know if I forgot someone, I'll fix that ASAP ;) )
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ targetCompatibility = 1.7
 
 group = 'com.ullink.slack'
 archivesBaseName = 'simpleslackapi'
-version = '0.5.0'
+version = '0.5.1'
 
 task copyRuntimeLibs(type: Copy) {
   into "lib"
@@ -109,7 +109,12 @@ def pomConfig = {
             name 'Georges Gomes'
         }
         contributor {
-            name 'François Valdy'
+            name 'Franï¿½ois Valdy'
+        }
+        contributor {
+            name 'Harry Fox'
+            email 'harry.fox.ic@icloud.com'
+            url 'https://github.com/ParaPenguin'
         }
     }
     scm {

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ def pomConfig = {
             name 'Georges Gomes'
         }
         contributor {
-            name 'Fran�ois Valdy'
+            name 'François Valdy'
         }
         contributor {
             name 'Harry Fox'

--- a/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
+++ b/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
@@ -53,9 +53,17 @@ public interface SlackSession {
 
     SlackMessageHandle<SlackMessageReply> deleteMessage(String timeStamp, SlackChannel channel);
 
+    SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, String message, SlackAttachment attachment, SlackChatConfiguration chatConfiguration, boolean unfurl);
+
     SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, String message, SlackAttachment attachment, SlackChatConfiguration chatConfiguration);
 
+    SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, String message, SlackAttachment attachment, boolean unfurl);
+
     SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, String message, SlackAttachment attachment);
+
+    SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, String message, boolean unfurl);
+
+    SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, String message);
 
     SlackMessageHandle<SlackMessageReply> sendMessageToUser(SlackUser user, String message, SlackAttachment attachment);
     

--- a/src/main/java/com/ullink/slack/simpleslackapi/impl/AbstractSlackSessionImpl.java
+++ b/src/main/java/com/ullink/slack/simpleslackapi/impl/AbstractSlackSessionImpl.java
@@ -52,7 +52,7 @@ abstract class AbstractSlackSessionImpl implements SlackSession
     protected List<ReactionRemovedListener> reactionRemovedListener = new ArrayList<>();
 
     static final SlackChatConfiguration DEFAULT_CONFIGURATION = SlackChatConfiguration.getConfiguration().asUser();
-
+    static final boolean DEFAULT_UNFURL = true;
 
     @Override
     public Collection<SlackChannel> getChannels()
@@ -156,6 +156,30 @@ abstract class AbstractSlackSessionImpl implements SlackSession
     public SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, String message, SlackAttachment attachment)
     {
         return sendMessage(channel, message, attachment, DEFAULT_CONFIGURATION);
+    }
+
+    @Override
+    public SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, String message)
+    {
+        return sendMessage(channel, message, DEFAULT_UNFURL);
+    }
+
+    @Override
+    public SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, String message, boolean unfurl)
+    {
+        return sendMessage(channel, message, null, DEFAULT_CONFIGURATION, unfurl);
+    }
+
+    @Override
+    public SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, String message, SlackAttachment attachment, boolean unfurl)
+    {
+        return sendMessage(channel, message, attachment, DEFAULT_CONFIGURATION, unfurl);
+    }
+
+    @Override
+    public SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, String message, SlackAttachment attachment, SlackChatConfiguration chatConfiguration)
+    {
+        return sendMessage(channel, message, null, chatConfiguration, DEFAULT_UNFURL);
     }
 
     @Override

--- a/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -431,7 +431,7 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
     }
 
     @Override
-    public SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, String message, SlackAttachment attachment, SlackChatConfiguration chatConfiguration)
+    public SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, String message, SlackAttachment attachment, SlackChatConfiguration chatConfiguration, boolean unfurl)
     {
         SlackMessageHandleImpl<SlackMessageReply> handle = new SlackMessageHandleImpl<SlackMessageReply>(getNextMessageId());
         Map<String, String> arguments = new HashMap<>();
@@ -457,6 +457,11 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
         if (attachment != null)
         {
             arguments.put("attachments", SlackJSONAttachmentFormatter.encodeAttachments(attachment).toString());
+        }
+        if (!unfurl)
+        {
+            arguments.put("unfurl_links", "false");
+            arguments.put("unfurl_media", "false");
         }
 
         postSlackCommand(arguments, CHAT_POST_MESSAGE_COMMAND, handle);

--- a/src/test/java/com/ullink/slack/simpleslackapi/impl/TestAbstractSlackSessionImpl.java
+++ b/src/test/java/com/ullink/slack/simpleslackapi/impl/TestAbstractSlackSessionImpl.java
@@ -49,7 +49,7 @@ public class TestAbstractSlackSessionImpl
         }
 
         @Override
-        public SlackMessageHandle sendMessage(SlackChannel channel, String message, SlackAttachment attachment, SlackChatConfiguration chatConfiguration)
+        public SlackMessageHandle sendMessage(SlackChannel channel, String message, SlackAttachment attachment, SlackChatConfiguration chatConfiguration, boolean unfurl)
         {
             return null;
         }

--- a/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONMessageParser.java
+++ b/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONMessageParser.java
@@ -78,7 +78,7 @@ public class TestSlackJSONMessageParser {
             }
 
             @Override
-            public SlackMessageHandle sendMessage(SlackChannel channel, String message, SlackAttachment attachment, SlackChatConfiguration chatConfiguration) {
+            public SlackMessageHandle sendMessage(SlackChannel channel, String message, SlackAttachment attachment, SlackChatConfiguration chatConfiguration, boolean unfurl) {
                 throw new UnsupportedOperationException();
             }
 


### PR DESCRIPTION
I wanted to be able to post to a channel _without_ links unfurling themselves, this code should resolve that, by adding an unfurl boolean to the command.

I also added a method that removes the SlackAttachment parameter, because a lot of the time, you don't want to send one. Default functionality is unaltered, I bumped the version number to 0.5.1, and added myself as a contributor (not sure if I was supposed to do this, since it's such a small change).