### PR TITLE
Fix multiparty direct messages

### DIFF
--- a/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -576,6 +576,19 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
         }
         arguments.put("users", strBuilder.toString());
         postSlackCommand(arguments, MULTIPARTY_DIRECT_MESSAGE_OPEN_CHANNEL_COMMAND, handle);
+
+        SlackMessageHandleImpl<?> check = handle;
+        SlackReply reply = check.getReply();
+        if (reply instanceof GenericSlackReply) {
+            JSONObject obj = ((GenericSlackReply) reply).getPlainAnswer();
+
+            Object ok = obj.get("ok");
+            if (ok != null && ok instanceof Boolean && !((Boolean) ok)) {
+                LOGGER.debug("Error occurred while performing command: '" + obj.get("error") + "'");
+                return null;
+            }
+        }
+
         return handle;
     }
 


### PR DESCRIPTION
This PR is in response to issue #42.

This should work, I tested it as much as I knew how to. Essentially it's because the multiparty direct message returns `group`, not `channel`. Also if an error is thrown, the response is completely different, but the handle still expects that class. I did my best to make the error known to those who are writing their projects, and returned null.

Some error handling is needed, badly.