### PR TITLE
Added Listener for the user_change Slack event type

### DIFF
--- a/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
+++ b/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
@@ -16,6 +16,7 @@ import com.ullink.slack.simpleslackapi.listeners.SlackGroupJoinedListener;
 import com.ullink.slack.simpleslackapi.listeners.SlackMessageDeletedListener;
 import com.ullink.slack.simpleslackapi.listeners.SlackMessagePostedListener;
 import com.ullink.slack.simpleslackapi.listeners.SlackMessageUpdatedListener;
+import com.ullink.slack.simpleslackapi.listeners.SlackUserChangeListener;
 import com.ullink.slack.simpleslackapi.replies.GenericSlackReply;
 import com.ullink.slack.simpleslackapi.replies.SlackChannelReply;
 import com.ullink.slack.simpleslackapi.replies.SlackMessageReply;
@@ -154,5 +155,9 @@ public interface SlackSession {
     void addReactionRemovedListener(ReactionRemovedListener listener);
     
     void removeReactionRemovedListener(ReactionRemovedListener listener);
+
+    void addSlackUserChangeListener(SlackUserChangeListener listener);
+
+    void removeSlackUserChangeListener(SlackUserChangeListener listener);
 
 }

--- a/src/main/java/com/ullink/slack/simpleslackapi/events/EventType.java
+++ b/src/main/java/com/ullink/slack/simpleslackapi/events/EventType.java
@@ -14,6 +14,7 @@ public enum EventType
     GROUP_JOINED("group_joined"),
     REACTION_ADDED("reaction_added"),
     REACTION_REMOVED("reaction_removed"),
+    USER_CHANGE("user_change"),
     OTHER("-");
 
     private static final Map<String, EventType> CODE_MAP = new HashMap<>();

--- a/src/main/java/com/ullink/slack/simpleslackapi/events/SlackEventType.java
+++ b/src/main/java/com/ullink/slack/simpleslackapi/events/SlackEventType.java
@@ -15,5 +15,6 @@ public enum SlackEventType
     SLACK_CONNECTED,
     REACTION_ADDED,
     REACTION_REMOVED,
+    SLACK_USER_CHANGE,
     UNKNOWN;
 }

--- a/src/main/java/com/ullink/slack/simpleslackapi/events/SlackUserChange.java
+++ b/src/main/java/com/ullink/slack/simpleslackapi/events/SlackUserChange.java
@@ -1,0 +1,8 @@
+package com.ullink.slack.simpleslackapi.events;
+
+import com.ullink.slack.simpleslackapi.SlackUser;
+
+public interface SlackUserChange extends SlackEvent {
+
+    SlackUser getUser();
+}

--- a/src/main/java/com/ullink/slack/simpleslackapi/impl/AbstractSlackSessionImpl.java
+++ b/src/main/java/com/ullink/slack/simpleslackapi/impl/AbstractSlackSessionImpl.java
@@ -5,8 +5,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.ullink.slack.simpleslackapi.SlackAttachment;
 import com.ullink.slack.simpleslackapi.SlackBot;
 import com.ullink.slack.simpleslackapi.SlackChannel;
@@ -27,6 +25,7 @@ import com.ullink.slack.simpleslackapi.listeners.SlackGroupJoinedListener;
 import com.ullink.slack.simpleslackapi.listeners.SlackMessageDeletedListener;
 import com.ullink.slack.simpleslackapi.listeners.SlackMessagePostedListener;
 import com.ullink.slack.simpleslackapi.listeners.SlackMessageUpdatedListener;
+import com.ullink.slack.simpleslackapi.listeners.SlackUserChangeListener;
 import com.ullink.slack.simpleslackapi.replies.SlackMessageReply;
 
 abstract class AbstractSlackSessionImpl implements SlackSession
@@ -46,10 +45,10 @@ abstract class AbstractSlackSessionImpl implements SlackSession
     protected List<SlackMessageDeletedListener>    messageDeletedListener   = new ArrayList<SlackMessageDeletedListener>();
     protected List<SlackMessagePostedListener>     messagePostedListener    = new ArrayList<SlackMessagePostedListener>();
     protected List<SlackMessageUpdatedListener>    messageUpdatedListener   = new ArrayList<SlackMessageUpdatedListener>();
-    protected List<SlackConnectedListener>         slackConnectedListener    = new ArrayList<SlackConnectedListener>();
-    protected List<SlackConnectedListener> slackConnectedLinster = new ArrayList<>();
-    protected List<ReactionAddedListener> reactionAddedListener = new ArrayList<>();
-    protected List<ReactionRemovedListener> reactionRemovedListener = new ArrayList<>();
+    protected List<SlackConnectedListener>         slackConnectedListener   = new ArrayList<SlackConnectedListener>();
+    protected List<ReactionAddedListener>          reactionAddedListener    = new ArrayList<>();
+    protected List<ReactionRemovedListener>        reactionRemovedListener  = new ArrayList<>();
+    protected List<SlackUserChangeListener>        slackUserChangeListener  = new ArrayList<>();
 
     static final SlackChatConfiguration DEFAULT_CONFIGURATION = SlackChatConfiguration.getConfiguration().asUser();
     static final boolean DEFAULT_UNFURL = true;
@@ -320,5 +319,14 @@ abstract class AbstractSlackSessionImpl implements SlackSession
         reactionRemovedListener.remove(listener);
     }
 
+    @Override
+    public void addSlackUserChangeListener(SlackUserChangeListener listener) {
+        slackUserChangeListener.add(listener);
+    }
+
+    @Override
+    public void removeSlackUserChangeListener(SlackUserChangeListener listener) {
+        slackUserChangeListener.remove(listener);
+    }
 }
 

--- a/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONMessageParser.java
+++ b/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONMessageParser.java
@@ -18,6 +18,7 @@ import com.ullink.slack.simpleslackapi.events.SlackChannelRenamed;
 import com.ullink.slack.simpleslackapi.events.SlackChannelUnarchived;
 import com.ullink.slack.simpleslackapi.events.SlackEvent;
 import com.ullink.slack.simpleslackapi.events.SlackGroupJoined;
+import com.ullink.slack.simpleslackapi.events.SlackUserChange;
 
 class SlackJSONMessageParser
 {
@@ -85,6 +86,8 @@ class SlackJSONMessageParser
                 return extractReactionAddedEvent(slackSession, obj);
             case REACTION_REMOVED:
                 return extractReactionRemovedEvent(slackSession, obj);
+            case USER_CHANGE:
+                return extractUserChangeEvent(slackSession, obj);
             default:
                 return SlackEvent.UNKNOWN_EVENT;
         }
@@ -299,6 +302,12 @@ class SlackJSONMessageParser
             }
         }
         return reacs;
+    }
+
+    private static SlackUserChange extractUserChangeEvent(SlackSession slackSession, JSONObject obj) {
+        JSONObject user = (JSONObject) obj.get("user");
+        SlackUser slackUser = SlackJSONParsingUtils.buildSlackUser(user);
+        return new SlackUserChangeImpl(slackUser);
     }
 }
 

--- a/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackUserChangeImpl.java
+++ b/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackUserChangeImpl.java
@@ -1,0 +1,24 @@
+package com.ullink.slack.simpleslackapi.impl;
+
+import com.ullink.slack.simpleslackapi.SlackUser;
+import com.ullink.slack.simpleslackapi.events.SlackEventType;
+import com.ullink.slack.simpleslackapi.events.SlackUserChange;
+
+public class SlackUserChangeImpl implements SlackUserChange {
+
+    private SlackUser slackUser;
+
+    SlackUserChangeImpl(SlackUser slackUser) {
+        this.slackUser = slackUser;
+    }
+
+    @Override
+    public SlackUser getUser() {
+        return slackUser;
+    }
+
+    @Override
+    public SlackEventType getEventType() {
+        return SlackEventType.SLACK_USER_CHANGE;
+    }
+}

--- a/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -10,12 +10,12 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import javax.websocket.DeploymentException;
 import javax.websocket.Endpoint;
 import javax.websocket.EndpointConfig;
 import javax.websocket.MessageHandler;
 import javax.websocket.Session;
+import com.google.common.io.CharStreams;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
@@ -34,7 +34,6 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.google.common.io.CharStreams;
 import com.ullink.slack.simpleslackapi.SlackAttachment;
 import com.ullink.slack.simpleslackapi.SlackChannel;
 import com.ullink.slack.simpleslackapi.SlackMessageHandle;
@@ -54,6 +53,7 @@ import com.ullink.slack.simpleslackapi.events.SlackGroupJoined;
 import com.ullink.slack.simpleslackapi.events.SlackMessageDeleted;
 import com.ullink.slack.simpleslackapi.events.SlackMessagePosted;
 import com.ullink.slack.simpleslackapi.events.SlackMessageUpdated;
+import com.ullink.slack.simpleslackapi.events.SlackUserChange;
 import com.ullink.slack.simpleslackapi.impl.SlackChatConfiguration.Avatar;
 import com.ullink.slack.simpleslackapi.listeners.SlackEventListener;
 import com.ullink.slack.simpleslackapi.replies.GenericSlackReply;
@@ -165,6 +165,8 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
                 case REACTION_REMOVED:
                     dispatchImpl((ReactionRemoved) event, reactionRemovedListener);
                     break;
+                case SLACK_USER_CHANGE:
+                    dispatchImpl((SlackUserChange) event, slackUserChangeListener);
                 case UNKNOWN:
                     throw new IllegalArgumentException("event not handled " + event);
             }
@@ -756,6 +758,11 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
             {
                 SlackGroupJoined slackGroupJoined = (SlackGroupJoined) slackEvent;
                 channels.put(slackGroupJoined.getSlackChannel().getId(), slackGroupJoined.getSlackChannel());
+            }
+            if (slackEvent instanceof SlackUserChange)
+            {
+                SlackUserChange slackUserChange = (SlackUserChange) slackEvent;
+                users.put(slackUserChange.getUser().getId(), slackUserChange.getUser());
             }
             dispatcher.dispatch(slackEvent);
         }

--- a/src/main/java/com/ullink/slack/simpleslackapi/listeners/SlackUserChangeListener.java
+++ b/src/main/java/com/ullink/slack/simpleslackapi/listeners/SlackUserChangeListener.java
@@ -1,0 +1,6 @@
+package com.ullink.slack.simpleslackapi.listeners;
+
+import com.ullink.slack.simpleslackapi.events.SlackUserChange;
+
+public interface SlackUserChangeListener extends SlackEventListener<SlackUserChange> {
+}

--- a/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONMessageParser.java
+++ b/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONMessageParser.java
@@ -25,6 +25,7 @@ import com.ullink.slack.simpleslackapi.events.SlackEvent;
 import com.ullink.slack.simpleslackapi.events.SlackGroupJoined;
 import com.ullink.slack.simpleslackapi.events.SlackMessageDeleted;
 import com.ullink.slack.simpleslackapi.events.SlackMessagePosted;
+import com.ullink.slack.simpleslackapi.events.SlackUserChange;
 import com.ullink.slack.simpleslackapi.replies.GenericSlackReply;
 import com.ullink.slack.simpleslackapi.replies.SlackChannelReply;
 import com.ullink.slack.simpleslackapi.replies.SlackReply;
@@ -49,6 +50,8 @@ public class TestSlackJSONMessageParser {
     private static final String TEST_REACTION = " \"reaction\":\"thumbsup\", \"item\": {\"channel\":\"NEWCHANNEL\",\"ts\":\"1360782804.083113\"}";
     private static final String TEST_REACTION_ADDED = "{\"type\":\"reaction_added\", " + TEST_REACTION + "}";
     private static final String TEST_REACTION_REMOVED = "{\"type\":\"reaction_removed\", " + TEST_REACTION + "}";
+
+    private static final String TEST_USER_CHANGE = "{\"type\": \"user_change\",\"user\": {\"id\": \"TESTUSER1\", \"name\": \"test user 1\"}}";
 
     @Before
     public void setup() {
@@ -302,5 +305,18 @@ public class TestSlackJSONMessageParser {
         Assert.assertTrue(channel.getName().equals("new channel"));
         Assert.assertTrue(channel.getPurpose().equals("This channel so new it aint even old yet"));
         Assert.assertTrue(channel.getTopic().equals("To have something new"));
+    }
+
+    @Test
+    public void testUserChange() throws ParseException {
+        JSONParser parser = new JSONParser();
+        JSONObject object = (JSONObject) parser.parse(TEST_USER_CHANGE);
+        SlackEvent event = SlackJSONMessageParser.decode(session, object);
+        Assertions.assertThat(event).isInstanceOf(SlackUserChange.class);
+        SlackUserChange slackUserChange = (SlackUserChange)event;
+        SlackUser user = slackUserChange.getUser();
+        Assertions.assertThat(user).isNotNull();
+        Assertions.assertThat(user.getId()).isEqualTo("TESTUSER1");
+        Assertions.assertThat(session.findUserById("TESTUSER1").getUserName()).isEqualTo(user.getUserName());
     }
 }


### PR DESCRIPTION
Hello,

I have added the ability to listen to the user_change event from Slack. This event typically triggers when someone changes it's own nickname, or any other personal info.
Upon triggering of this event, the internal users map is also updated.

Thanks !