### PR TITLE
Added SlackSession#setPresence(SlackPresence)

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
@@ -78,6 +78,8 @@ public interface SlackSession {
 
     SlackPersona.SlackPresence getPresence(SlackPersona persona);
 
+    void setPresence(SlackPersona.SlackPresence presence);
+
     SlackMessageHandle<GenericSlackReply> postGenericSlackCommand(Map<String, String> params, String command);
 
     void addchannelArchivedListener(SlackChannelArchivedListener listener);

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -713,8 +713,8 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
     }
 
     public void setPresence(SlackPersona.SlackPresence presence) {
-        if(presence == SlackPersona.SlackPresence.UNKNOWN) {
-            throw new IllegalArgumentException("presence cannot be unknown");
+        if(presence == SlackPersona.SlackPresence.UNKNOWN || presence == SlackPersona.SlackPresence.ACTIVE) {
+            throw new IllegalArgumentException("Presence must be either AWAY or AUTO");
         }
         HttpClient client = getHttpClient();
         HttpPost request = new HttpPost(SLACK_API_HTTPS_ROOT + SET_PERSONA_ACTIVE);

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -71,6 +71,8 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
     
     private static final String INVITE_USER_COMMAND     = "users.admin.invite";
 
+    private static final String SET_PERSONA_ACTIVE = "users.setPresence";
+
 
     @Override
     public SlackMessageHandle<SlackMessageReply> sendMessageToUser(SlackUser user, String message, SlackAttachment attachment) {
@@ -708,6 +710,27 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
             e.printStackTrace();
         }
         return SlackPersona.SlackPresence.UNKNOWN;
+    }
+
+    public void setPresence(SlackPersona.SlackPresence presence) {
+        if(presence == SlackPersona.SlackPresence.UNKNOWN) {
+            throw new IllegalArgumentException("presence cannot be unknown");
+        }
+        HttpClient client = getHttpClient();
+        HttpPost request = new HttpPost(SLACK_API_HTTPS_ROOT + SET_PERSONA_ACTIVE);
+        List<NameValuePair> nameValuePairList = new ArrayList<>();
+        nameValuePairList.add(new BasicNameValuePair("token", authToken));
+        nameValuePairList.add(new BasicNameValuePair("presence", presence.toString().toLowerCase()));
+        try {
+            request.setEntity(new UrlEncodedFormEntity(nameValuePairList, "UTF-8"));
+            HttpResponse response = client.execute(request);
+            String JSONResponse = CharStreams.toString(new InputStreamReader(response.getEntity().getContent()));
+            LOGGER.debug("JSON Response=" + JSONResponse);
+            JSONObject resultObj = parseObject(JSONResponse);
+        }catch(IOException e) {
+            e.printStackTrace();
+        }
+
     }
 
     private synchronized long getNextMessageId()

--- a/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestAbstractSlackSessionImpl.java
+++ b/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestAbstractSlackSessionImpl.java
@@ -20,7 +20,9 @@ public class TestAbstractSlackSessionImpl
 
     private class TestSlackSessionImpl extends AbstractSlackSessionImpl
     {
-
+        @Override
+        public void setPresence(SlackPersona.SlackPresence presence) {
+        }
         @Override
         public void connect()
         {
@@ -150,6 +152,8 @@ public class TestAbstractSlackSessionImpl
         public SlackMessageHandle sendMessageToUser(String userName, String message, SlackAttachment attachment) {
             throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
+
+
     }
 
     @Test

--- a/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONMessageParser.java
+++ b/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONMessageParser.java
@@ -57,7 +57,10 @@ public class TestSlackJSONMessageParser {
     @Before
     public void setup() {
         session = new AbstractSlackSessionImpl() {
-            
+
+            @Override
+            public void setPresence(SlackPersona.SlackPresence presence) {};
+
             @Override
             public void connect() {
                 SlackUser user1 = new SlackUserImpl("TESTUSER1", "test user 1", "", "", false, false, false, false, false, false, false, "tz", "tzLabel", new Integer(0));


### PR DESCRIPTION
This is a method that can be used to set the presence of a slack bot. The persona on which the change is made is not mutable. 