### PR TITLE
Support for multiple attachments

### DIFF
--- a/samples/actions/src/main/java/actions/SendingMessages.java
+++ b/samples/actions/src/main/java/actions/SendingMessages.java
@@ -1,9 +1,6 @@
 package actions;
 
-import com.ullink.slack.simpleslackapi.SlackChannel;
-import com.ullink.slack.simpleslackapi.SlackMessageHandle;
-import com.ullink.slack.simpleslackapi.SlackSession;
-import com.ullink.slack.simpleslackapi.SlackUser;
+import com.ullink.slack.simpleslackapi.*;
 import com.ullink.slack.simpleslackapi.replies.SlackChannelReply;
 
 /**
@@ -78,4 +75,22 @@ public class SendingMessages
         session.sendMessage(channel, "Hi, how are you guys", null);
     }
 
+    /**
+     * This method shows how to send a message using the PreparedMessage builder (allows for multiple attachments)
+     */
+    public void sendUsingPreparedMessage(SlackSession session)
+    {
+        //get a channel
+        SlackChannel channel = session.findChannelByName("achannel");
+
+        //build a message object
+        SlackPreparedMessage preparedMessage = new SlackPreparedMessage.Builder()
+                .withMessage("Hey, this is a message")
+                .withUnfurl(false)
+                .addAttachment(new SlackAttachment())
+                .addAttachment(new SlackAttachment())
+                .build();
+
+        session.sendMessage(channel, preparedMessage);
+    }
 }

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackPreparedMessage.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackPreparedMessage.java
@@ -1,0 +1,81 @@
+package com.ullink.slack.simpleslackapi;
+
+import com.google.common.collect.Lists;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class SlackPreparedMessage {
+    private final String message;
+    private final boolean unfurl;
+    private final SlackAttachment[] attachments;
+
+    private SlackPreparedMessage(String message, boolean unfurl, SlackAttachment[] attachments) {
+        this.message = message;
+        this.unfurl = unfurl;
+        this.attachments = attachments;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public boolean isUnfurl() {
+        return unfurl;
+    }
+
+    public SlackAttachment[] getAttachments() {
+        return attachments;
+    }
+
+    public static class Builder {
+        String message;
+        boolean unfurl;
+        List<SlackAttachment> attachments;
+
+        public Builder() {
+            this.attachments = Lists.newArrayList();
+        }
+
+        public Builder withMessage(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder withUnfurl(boolean unfurl) {
+            this.unfurl = unfurl;
+            return this;
+        }
+
+        public Builder addAttachment(SlackAttachment attachment) {
+            this.attachments.add(attachment);
+            return this;
+        }
+
+        public Builder addAttachments(List<SlackAttachment> attachments) {
+            this.attachments.addAll(attachments);
+            return this;
+        }
+
+        public Builder withAttachments(List<SlackAttachment> attachments) {
+            this.attachments = attachments;
+            return this;
+        }
+
+        public SlackPreparedMessage build() {
+            return new SlackPreparedMessage(
+                    message,
+                    unfurl,
+                    attachments.toArray(new SlackAttachment[]{}));
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "SlackPreparedMessage{" +
+                "message='" + message + '\'' +
+                ", unfurl=" + unfurl +
+                ", attachments=" + Arrays.toString(attachments) +
+                '}';
+    }
+}

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
@@ -1,14 +1,15 @@
 package com.ullink.slack.simpleslackapi;
 
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Map;
 import com.ullink.slack.simpleslackapi.impl.SlackChatConfiguration;
 import com.ullink.slack.simpleslackapi.listeners.*;
 import com.ullink.slack.simpleslackapi.replies.GenericSlackReply;
 import com.ullink.slack.simpleslackapi.replies.ParsedSlackReply;
 import com.ullink.slack.simpleslackapi.replies.SlackChannelReply;
 import com.ullink.slack.simpleslackapi.replies.SlackMessageReply;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
 
 public interface SlackSession {
 
@@ -41,6 +42,10 @@ public interface SlackSession {
     void disconnect() throws IOException;
 
     SlackMessageHandle<SlackMessageReply> deleteMessage(String timeStamp, SlackChannel channel);
+
+    SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, SlackPreparedMessage preparedMessage, SlackChatConfiguration chatConfiguration);
+
+    SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, SlackPreparedMessage preparedMessage);
 
     SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, String message, SlackAttachment attachment, SlackChatConfiguration chatConfiguration, boolean unfurl);
 

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/AbstractSlackSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/AbstractSlackSessionImpl.java
@@ -1,20 +1,10 @@
 package com.ullink.slack.simpleslackapi.impl;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import com.ullink.slack.simpleslackapi.SlackAttachment;
-import com.ullink.slack.simpleslackapi.SlackBot;
-import com.ullink.slack.simpleslackapi.SlackChannel;
-import com.ullink.slack.simpleslackapi.SlackMessageHandle;
-import com.ullink.slack.simpleslackapi.SlackPersona;
-import com.ullink.slack.simpleslackapi.SlackSession;
-import com.ullink.slack.simpleslackapi.SlackTeam;
-import com.ullink.slack.simpleslackapi.SlackUser;
+import com.ullink.slack.simpleslackapi.*;
 import com.ullink.slack.simpleslackapi.listeners.*;
 import com.ullink.slack.simpleslackapi.replies.SlackMessageReply;
+
+import java.util.*;
 
 abstract class AbstractSlackSessionImpl implements SlackSession
 {
@@ -172,6 +162,23 @@ abstract class AbstractSlackSessionImpl implements SlackSession
     public SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, String message, SlackAttachment attachment, SlackChatConfiguration chatConfiguration)
     {
         return sendMessage(channel, message, attachment, chatConfiguration, DEFAULT_UNFURL);
+    }
+
+    @Override
+    public SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, SlackPreparedMessage preparedMessage) {
+        return sendMessage(channel, preparedMessage, DEFAULT_CONFIGURATION);
+    }
+
+    @Override
+    public SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, String message, SlackAttachment attachment, SlackChatConfiguration chatConfiguration, boolean unfurl)
+    {
+        SlackPreparedMessage preparedMessage = new SlackPreparedMessage.Builder()
+                .withMessage(message)
+                .withUnfurl(unfurl)
+                .addAttachment(attachment)
+                .build();
+
+        return sendMessage(channel, preparedMessage, chatConfiguration);
     }
 
     @Override

--- a/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestAbstractSlackSessionImpl.java
+++ b/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestAbstractSlackSessionImpl.java
@@ -1,19 +1,15 @@
 package com.ullink.slack.simpleslackapi.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import com.ullink.slack.simpleslackapi.replies.ParsedSlackReply;
-import org.junit.Test;
-import com.ullink.slack.simpleslackapi.SlackAttachment;
-import com.ullink.slack.simpleslackapi.SlackChannel;
-import com.ullink.slack.simpleslackapi.SlackMessageHandle;
-import com.ullink.slack.simpleslackapi.SlackPersona;
-import com.ullink.slack.simpleslackapi.SlackSession;
-import com.ullink.slack.simpleslackapi.SlackUser;
+import com.ullink.slack.simpleslackapi.*;
 import com.ullink.slack.simpleslackapi.events.SlackConnected;
 import com.ullink.slack.simpleslackapi.listeners.SlackConnectedListener;
 import com.ullink.slack.simpleslackapi.replies.GenericSlackReply;
+import com.ullink.slack.simpleslackapi.replies.ParsedSlackReply;
 import com.ullink.slack.simpleslackapi.replies.SlackChannelReply;
+import com.ullink.slack.simpleslackapi.replies.SlackMessageReply;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestAbstractSlackSessionImpl
 {
@@ -52,12 +48,6 @@ public class TestAbstractSlackSessionImpl
         }
 
         @Override
-        public SlackMessageHandle sendMessage(SlackChannel channel, String message, SlackAttachment attachment, SlackChatConfiguration chatConfiguration, boolean unfurl)
-        {
-            return null;
-        }
-
-        @Override
         public SlackMessageHandle sendMessageOverWebSocket(SlackChannel channel, String message)
         {
             return null;
@@ -71,6 +61,11 @@ public class TestAbstractSlackSessionImpl
         @Override
         public SlackMessageHandle deleteMessage(String timeStamp, SlackChannel channel)
         {
+            return null;
+        }
+
+        @Override
+        public SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, SlackPreparedMessage preparedMessage, SlackChatConfiguration chatConfiguration) {
             return null;
         }
 

--- a/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONMessageParser.java
+++ b/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONMessageParser.java
@@ -1,9 +1,11 @@
 package com.ullink.slack.simpleslackapi.impl;
 
-import java.io.IOException;
-import java.util.Map;
-
+import com.ullink.slack.simpleslackapi.*;
+import com.ullink.slack.simpleslackapi.events.*;
+import com.ullink.slack.simpleslackapi.replies.GenericSlackReply;
 import com.ullink.slack.simpleslackapi.replies.ParsedSlackReply;
+import com.ullink.slack.simpleslackapi.replies.SlackChannelReply;
+import com.ullink.slack.simpleslackapi.replies.SlackMessageReply;
 import org.assertj.core.api.Assertions;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -11,25 +13,9 @@ import org.json.simple.parser.ParseException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import com.ullink.slack.simpleslackapi.SlackAttachment;
-import com.ullink.slack.simpleslackapi.SlackChannel;
-import com.ullink.slack.simpleslackapi.SlackMessageHandle;
-import com.ullink.slack.simpleslackapi.SlackPersona;
-import com.ullink.slack.simpleslackapi.SlackSession;
-import com.ullink.slack.simpleslackapi.SlackUser;
-import com.ullink.slack.simpleslackapi.events.ReactionAdded;
-import com.ullink.slack.simpleslackapi.events.ReactionRemoved;
-import com.ullink.slack.simpleslackapi.events.SlackChannelArchived;
-import com.ullink.slack.simpleslackapi.events.SlackChannelCreated;
-import com.ullink.slack.simpleslackapi.events.SlackChannelDeleted;
-import com.ullink.slack.simpleslackapi.events.SlackChannelUnarchived;
-import com.ullink.slack.simpleslackapi.events.SlackEvent;
-import com.ullink.slack.simpleslackapi.events.SlackGroupJoined;
-import com.ullink.slack.simpleslackapi.events.SlackMessageDeleted;
-import com.ullink.slack.simpleslackapi.events.SlackMessagePosted;
-import com.ullink.slack.simpleslackapi.events.SlackUserChange;
-import com.ullink.slack.simpleslackapi.replies.GenericSlackReply;
-import com.ullink.slack.simpleslackapi.replies.SlackChannelReply;
+
+import java.io.IOException;
+import java.util.Map;
 
 public class TestSlackJSONMessageParser {
 
@@ -85,11 +71,6 @@ public class TestSlackJSONMessageParser {
             }
 
             @Override
-            public SlackMessageHandle sendMessage(SlackChannel channel, String message, SlackAttachment attachment, SlackChatConfiguration chatConfiguration, boolean unfurl) {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
             public SlackMessageHandle sendMessageOverWebSocket(SlackChannel channel, String message) {
                 throw new UnsupportedOperationException();
             }
@@ -102,6 +83,11 @@ public class TestSlackJSONMessageParser {
             @Override
             public SlackMessageHandle deleteMessage(String timeStamp, SlackChannel channel) {
                 return null;
+            }
+
+            @Override
+            public SlackMessageHandle<SlackMessageReply> sendMessage(SlackChannel channel, SlackPreparedMessage preparedMessage, SlackChatConfiguration chatConfiguration) {
+                throw new UnsupportedOperationException();
             }
 
             @Override


### PR DESCRIPTION
Hey,

This PR adds support for multiple attachments in a single slack message. Since there were already so many different constructors for `sendMessage`, I didn't want to either introduce a breaking change, nor an added constructor for each scenario, I decided to create a `SlackPreapredMessage` class. Said class has a builder for ease-of-use. An example usage would be:

```
public void sendUsingPreparedMessage(SlackSession session)
{
    //get a channel
    SlackChannel channel = session.findChannelByName("achannel");

    //build a message object
    SlackPreparedMessage preparedMessage = new SlackPreparedMessage.Builder()
            .withMessage("Hey, this is a message")
            .withUnfurl(false)
            .addAttachment(new SlackAttachment())
            .addAttachment(new SlackAttachment())
            .build();

    session.sendMessage(channel, preparedMessage);
}
```