### PR TITLE
Added SlackSession#setHeartbeat(long, TimeUnit) 

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
@@ -3,6 +3,8 @@ package com.ullink.slack.simpleslackapi;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
 import com.ullink.slack.simpleslackapi.impl.SlackChatConfiguration;
 import com.ullink.slack.simpleslackapi.listeners.*;
 import com.ullink.slack.simpleslackapi.replies.GenericSlackReply;
@@ -161,4 +163,8 @@ public interface SlackSession {
     void addPinRemovedListener(PinRemovedListener listener);
   
     void removePinRemovedListener(PinRemovedListener listener);
+
+    long getHeartbeat();
+
+     void setHeartbeat(int heartbeat, TimeUnit unit);
 }

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackSessionFactory.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackSessionFactory.java
@@ -1,6 +1,8 @@
 package com.ullink.slack.simpleslackapi.impl;
 
 import java.net.Proxy;
+import java.util.concurrent.TimeUnit;
+
 import com.ullink.slack.simpleslackapi.SlackSession;
 
 public class SlackSessionFactory
@@ -15,4 +17,7 @@ public class SlackSessionFactory
         return new SlackWebSocketSessionImpl(authToken, proxyType, proxyAddress, proxyPort, true);
     }
 
+    public static SlackSession createWebSocketSlackSession(String authToken, int heartbeat, TimeUnit unit) {
+        return new SlackWebSocketSessionImpl(authToken, true, heartbeat, unit);
+    }
 }

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -806,7 +806,7 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
 
 
     public long getHeartbeat() {
-        return heartbeatTime;
+        return TimeUnit.MILLISECONDS.toSeconds(heartbeatTime);
     }
 
     public void setHeartbeat(int heartbeat, TimeUnit unit) {


### PR DESCRIPTION
Added getter and setter to SlackSession for the heartbeat time. setter takes a heartbeat time, and a TimeUnit enum to get the context of the number. From there the number is changed to millis and stored in a variable references by the heartbeat thread in SlackWebSocketSessionImpl. 