### PR TITLE
Added mutable heartbeat value to SlackWebSocketSessionImpl

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
@@ -10,6 +10,7 @@ import com.ullink.slack.simpleslackapi.replies.SlackMessageReply;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public interface SlackSession {
 
@@ -166,4 +167,8 @@ public interface SlackSession {
     void addPinRemovedListener(PinRemovedListener listener);
   
     void removePinRemovedListener(PinRemovedListener listener);
+
+    long getHeartbeat();
+
+    void setHeartbeat(long heartbeat, TimeUnit unit);
 }

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackSessionFactory.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackSessionFactory.java
@@ -1,6 +1,8 @@
 package com.ullink.slack.simpleslackapi.impl;
 
 import java.net.Proxy;
+import java.util.concurrent.TimeUnit;
+
 import com.ullink.slack.simpleslackapi.SlackSession;
 
 public class SlackSessionFactory
@@ -15,4 +17,7 @@ public class SlackSessionFactory
         return new SlackWebSocketSessionImpl(authToken, proxyType, proxyAddress, proxyPort, true);
     }
 
+    public static SlackSession createWebSocketSlackSession(String authToken, int heartbeat, TimeUnit unit) {
+        return new SlackWebSocketSessionImpl(authToken, true, heartbeat, unit);
+    }
 }

--- a/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestAbstractSlackSessionImpl.java
+++ b/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestAbstractSlackSessionImpl.java
@@ -9,6 +9,8 @@ import com.ullink.slack.simpleslackapi.replies.SlackChannelReply;
 import com.ullink.slack.simpleslackapi.replies.SlackMessageReply;
 import org.junit.Test;
 
+import java.util.concurrent.TimeUnit;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestAbstractSlackSessionImpl
@@ -148,7 +150,15 @@ public class TestAbstractSlackSessionImpl
             throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
 
+        @Override
+        public long getHeartbeat() {
+            return 0;
+        }
 
+        @Override
+        public void setHeartbeat(long heartbeat, TimeUnit unit) {
+
+        }
     }
 
     @Test

--- a/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONMessageParser.java
+++ b/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONMessageParser.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class TestSlackJSONMessageParser {
 
@@ -43,6 +44,16 @@ public class TestSlackJSONMessageParser {
     @Before
     public void setup() {
         session = new AbstractSlackSessionImpl() {
+
+            @Override
+            public long getHeartbeat() {
+                return 0;
+            }
+
+            @Override
+            public void setHeartbeat(long heartbeat, TimeUnit unit) {
+
+            }
 
             @Override
             public void setPresence(SlackPersona.SlackPresence presence) {};


### PR DESCRIPTION
With this the delay between heartbeat requests can be changed. Can either be set with SlackSessionFactory#createWebSocketSlackSession, or changed with SlackSession#setHeartbeat(long, TimeUnit)