### PR TITLE
Prevent IllegalArgumentException with WebSocketSlackSession.

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackSessionFactory.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackSessionFactory.java
@@ -9,7 +9,7 @@ public class SlackSessionFactory
 {
     public static SlackSession createWebSocketSlackSession(String authToken)
     {
-        return new SlackWebSocketSessionImpl(authToken, null, null, 0,true, 0, null);
+    	return new SlackWebSocketSessionImpl(authToken, true, 0, null);
     }
 
     public static SlackSession createWebSocketSlackSession(final String authToken, Proxy.Type proxyType, String proxyAddress, int proxyPort)

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -184,6 +184,12 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
     private Thread                            connectionMonitoringThread = null;
     private EventDispatcher                   dispatcher                 = new EventDispatcher();
     private long                              heartbeat;
+    
+    SlackWebSocketSessionImpl(String authToken, boolean reconnectOnDisconnection, long heartbeat, TimeUnit unit) {
+        this.authToken = authToken;
+        this.reconnectOnDisconnection = reconnectOnDisconnection;
+        this.heartbeat = heartbeat != 0 ? unit.toMillis(heartbeat) : 30000;
+    }
 
     SlackWebSocketSessionImpl(String authToken, Proxy.Type proxyType, String proxyAddress, int proxyPort, boolean reconnectOnDisconnection, long heartbeat, TimeUnit unit) {
         this.authToken = authToken;


### PR DESCRIPTION
Closes #74, and this resolves that issue. This change adds the previous existing constructor and prevents the creation of a HttpHost object with null parameters.