### PR TITLE
Annotating methods which access to url and urlDownload fields of SlackFile as deprecated

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackFile.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackFile.java
@@ -71,18 +71,22 @@ public class SlackFile {
         this.filetype = filetype;
     }
 
+    @Deprecated
     public String getUrl() {
         return url;
     }
 
+    @Deprecated
     public void setUrl(String url) {
         this.url = url;
     }
 
+    @Deprecated
     public String getUrlDownload() {
         return urlDownload;
     }
 
+    @Deprecated
     public void setUrlDownload(String urlDownload) {
         this.urlDownload = urlDownload;
     }


### PR DESCRIPTION
This fields are no longer relevant and always contain null. According to official slack documentation: "Please note that the url and url_download parameters have been deprecated. Please use url_private and url_private_download instead."