### PR TITLE
Missing "break" in event dispatcher switch case

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -165,6 +165,7 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
                     break;
                 case SLACK_DISCONNECTED:
                     dispatchImpl((SlackDisconnected) event, slackDisconnectedListener);
+                    break;
                 case UNKNOWN:
                     throw new IllegalArgumentException("event not handled " + event);
             }


### PR DESCRIPTION
throws exception on SLACK_DISCONNECTED event as it was UNKNOWN