### PR TITLE
Adding SlackAction in SlackAttachment

### DIFF
--- a/sources/build.gradle
+++ b/sources/build.gradle
@@ -90,6 +90,11 @@ def pomConfig = {
             email 'purbleguy@gmail.com'
             url 'http://redrield.github.io/'
         }
+        contributor {
+            name 'Dmitry Che'
+            email 'morfeusys@gmail.com'
+            url 'https://github.com/Morfeusys'
+        }
     }
     scm {
         connection 'scm:git:git@github.com:Ullink/simple-slack-api.git'

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackAction.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackAction.java
@@ -1,0 +1,52 @@
+package com.ullink.slack.simpleslackapi;
+
+public class SlackAction {
+    public static final String TYPE_BUTTON = "button";
+
+    private String name;
+    private String text;
+    private String type;
+    private String value;
+
+    public SlackAction() {
+    }
+
+    public SlackAction(String name, String text, String type, String value) {
+        this.name = name;
+        this.text = text;
+        this.type = type;
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackAttachment.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackAttachment.java
@@ -10,6 +10,7 @@ public class SlackAttachment {
     private String              title;
     private String              titleLink;
     private String              fallback;
+    private String              callback_id;
     private String              text;
     private String              pretext;
     private String              thumb_url;
@@ -19,6 +20,8 @@ public class SlackAttachment {
     private Map<String, String> miscRootFields;
 
     private List<SlackField>    fields = new ArrayList<>();
+
+    private List<SlackAction>   actions = new ArrayList<>();
 
     private List<String>        markdown_in;
 
@@ -40,6 +43,10 @@ public class SlackAttachment {
 
     public void addField(String title, String value, boolean isShort) {
         fields.add(new SlackField(title, value, isShort));
+    }
+
+    public void addAction(String name, String value, String text, String type) {
+        actions.add(new SlackAction(name, text, type, value));
     }
 
     public void addMarkdownIn(String value) {
@@ -71,6 +78,10 @@ public class SlackAttachment {
         this.fallback = fallback;
     }
 
+    public void setCallbackId(String callback_id) {
+        this.callback_id = callback_id;
+    }
+
     public void setText(String text)
     {
         this.text = text;
@@ -98,6 +109,10 @@ public class SlackAttachment {
         return fallback;
     }
 
+    public String getCallbackId() {
+        return callback_id;
+    }
+
     public String getText() {
         return text;
     }
@@ -120,6 +135,10 @@ public class SlackAttachment {
 
     public List<SlackField> getFields() {
         return fields;
+    }
+
+    public List<SlackAction> getActions() {
+        return actions;
     }
 
     public List<String> getMarkdown_in() {

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONAttachmentFormatter.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONAttachmentFormatter.java
@@ -1,9 +1,10 @@
 package com.ullink.slack.simpleslackapi.impl;
 
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import com.ullink.slack.simpleslackapi.SlackAction;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import com.ullink.slack.simpleslackapi.SlackAttachment;
@@ -36,6 +37,9 @@ class SlackJSONAttachmentFormatter {
             if (attachment.getFallback() != null) {
                 attachmentJSON.put("fallback", attachment.getFallback());
             }
+            if (attachment.getCallbackId() != null) {
+                attachmentJSON.put("callback_id", attachment.getCallbackId());
+            }
             if (attachment.getMiscRootFields() != null) {
                 for (Map.Entry<String, String> entry : attachment.getMiscRootFields().entrySet()) {
                     attachmentJSON.put(entry.getKey(), entry.getValue());
@@ -48,6 +52,9 @@ class SlackJSONAttachmentFormatter {
             }
             if (attachment.getFields() != null && !attachment.getFields().isEmpty()) {
                 attachmentJSON.put("fields", encodeAttachmentFields(attachment.getFields()));
+            }
+            if (attachment.getActions() != null && !attachment.getActions().isEmpty()) {
+                attachmentJSON.put("actions", encodeAttachmentActions(attachment.getActions()));
             }
 
         }
@@ -69,6 +76,31 @@ class SlackJSONAttachmentFormatter {
                 fieldJSON.put("value", field.getValue());
             }
             fieldJSON.put("short", field.isShort());
+        }
+        return toReturn;
+    }
+
+    private static List<JSONObject> encodeAttachmentActions(List<SlackAction> actions) {
+        List<JSONObject> toReturn = new ArrayList<>();
+        for (SlackAction action : actions) {
+            JSONObject actionJSON = new JSONObject();
+            toReturn.add(actionJSON);
+            if (action.getName() != null)
+            {
+                actionJSON.put("name", action.getName());
+            }
+            if (action.getText() != null)
+            {
+                actionJSON.put("text", action.getText());
+            }
+            if (action.getType() != null)
+            {
+                actionJSON.put("type", action.getType());
+            }
+            if (action.getValue() != null)
+            {
+                actionJSON.put("value", action.getValue());
+            }
         }
         return toReturn;
     }

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONAttachmentFormatter.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONAttachmentFormatter.java
@@ -4,10 +4,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.ullink.slack.simpleslackapi.SlackAction;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import com.ullink.slack.simpleslackapi.SlackAttachment;
+import com.ullink.slack.simpleslackapi.SlackAction;
 import com.ullink.slack.simpleslackapi.SlackField;
 
 class SlackJSONAttachmentFormatter {

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONMessageParser.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONMessageParser.java
@@ -6,7 +6,6 @@ import java.util.Map;
 
 import com.ullink.slack.simpleslackapi.*;
 import com.ullink.slack.simpleslackapi.events.*;
-import jdk.nashorn.api.scripting.JSObject;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 


### PR DESCRIPTION
Once Slack has introduced [Interactive buttons](https://api.slack.com/docs/message-buttons), we have to support "actions" field inside an "attachment".