### PR TITLE
Added integrations support

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackIntegration.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackIntegration.java
@@ -1,0 +1,7 @@
+package com.ullink.slack.simpleslackapi;
+
+public interface SlackIntegration {
+	String getId();
+	String getName();
+	boolean isDeleted();
+}

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackPersona.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackPersona.java
@@ -21,4 +21,5 @@ public interface SlackPersona {
     String getTimeZone();
     String getTimeZoneLabel();
     Integer getTimeZoneOffset();
+    SlackPresence getPresence();
 }

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
@@ -19,6 +19,8 @@ public interface SlackSession {
 
     Collection<SlackBot> getBots();
 
+    Collection<SlackIntegration> getIntegrations();
+
     SlackChannel findChannelByName(String channelName);
 
     SlackChannel findChannelById(String channelId);

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/AbstractSlackSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/AbstractSlackSessionImpl.java
@@ -11,6 +11,7 @@ abstract class AbstractSlackSessionImpl implements SlackSession
 
     protected Map<String, SlackChannel>            channels                 = new HashMap<>();
     protected Map<String, SlackUser>               users                    = new HashMap<>();
+    protected Map<String, SlackIntegration>        integrations             = new HashMap<>();
     protected SlackPersona                         sessionPersona;
     protected SlackTeam                            team;
 
@@ -53,6 +54,11 @@ abstract class AbstractSlackSessionImpl implements SlackSession
     public Collection<SlackUser> getUsers()
     {
         return new ArrayList<>(users.values());
+    }
+
+    @Override
+    public Collection<SlackIntegration> getIntegrations() {
+        return new ArrayList<>(integrations.values());
     }
 
     @Override

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackBotImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackBotImpl.java
@@ -6,9 +6,9 @@ import com.ullink.slack.simpleslackapi.SlackBot;
 class SlackBotImpl extends SlackPersonaImpl implements SlackBot
 {
     SlackBotImpl(String id, String userName, String realName, String userMail, String userSkype, String userPhone, String userTitle,
-                 boolean deleted, boolean admin, boolean owner, boolean primaryOwner, boolean restricted, boolean ultraRestricted)
+                 boolean deleted, boolean admin, boolean owner, boolean primaryOwner, boolean restricted, boolean ultraRestricted, SlackPresence presence)
     {
-        super(id, userName, realName, userMail, userSkype, userPhone, userTitle, deleted, admin, owner, primaryOwner, restricted, ultraRestricted, true,null,null,0);
+        super(id, userName, realName, userMail, userSkype, userPhone, userTitle, deleted, admin, owner, primaryOwner, restricted, ultraRestricted, true,null,null,0, presence);
     }
 
 }

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackIntegrationImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackIntegrationImpl.java
@@ -1,0 +1,31 @@
+package com.ullink.slack.simpleslackapi.impl;
+
+import com.ullink.slack.simpleslackapi.SlackIntegration;
+
+class SlackIntegrationImpl implements SlackIntegration {
+
+	private final String id;
+	private final String name;
+	private final boolean deleted;
+
+	public SlackIntegrationImpl(String id, String name, boolean deleted) {
+		this.id = id;
+		this.name = name;
+		this.deleted = deleted;
+	}
+
+	@Override
+	public String getId() {
+		return id;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public boolean isDeleted() {
+		return deleted;
+	}
+}

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONParsingUtils.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONParsingUtils.java
@@ -1,6 +1,7 @@
 package com.ullink.slack.simpleslackapi.impl;
 
 import com.ullink.slack.simpleslackapi.SlackIntegration;
+import com.ullink.slack.simpleslackapi.SlackPersona;
 import com.ullink.slack.simpleslackapi.SlackTeam;
 import com.ullink.slack.simpleslackapi.SlackUser;
 import org.json.simple.JSONArray;
@@ -41,7 +42,18 @@ class SlackJSONParsingUtils {
             title = (String) profileJSON.get("title");
             phone = (String) profileJSON.get("phone");
         }
-        return new SlackUserImpl(id, name, realName, email, skype, title, phone, deleted, admin, owner, primaryOwner, restricted, ultraRestricted, bot, tz, tzLabel, tzOffset == null ? null : new Integer(tzOffset.intValue()));
+
+        String presence = (String) jsonUser.get("presence");
+        SlackPersona.SlackPresence slackPresence = SlackPersona.SlackPresence.UNKNOWN;
+        if ("active".equals(presence))
+        {
+            slackPresence = SlackPersona.SlackPresence.ACTIVE;
+        }
+        if ("away".equals(presence))
+        {
+            slackPresence = SlackPersona.SlackPresence.AWAY;
+        }
+        return new SlackUserImpl(id, name, realName, email, skype, title, phone, deleted, admin, owner, primaryOwner, restricted, ultraRestricted, bot, tz, tzLabel, tzOffset == null ? null : new Integer(tzOffset.intValue()), slackPresence);
     }
 
     private static Boolean ifNullFalse(JSONObject jsonUser, String field) {

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONParsingUtils.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONParsingUtils.java
@@ -1,10 +1,12 @@
 package com.ullink.slack.simpleslackapi.impl;
 
-import java.util.Map;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
+import com.ullink.slack.simpleslackapi.SlackIntegration;
 import com.ullink.slack.simpleslackapi.SlackTeam;
 import com.ullink.slack.simpleslackapi.SlackUser;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+
+import java.util.Map;
 
 class SlackJSONParsingUtils {
 
@@ -97,5 +99,12 @@ class SlackJSONParsingUtils {
         String name = (String) jsonTeam.get("name");
         String domain = (String) jsonTeam.get("domain");
         return new SlackTeamImpl(id, name, domain);
+    }
+
+    static final SlackIntegration buildSlackIntegration(JSONObject jsonIntegration) {
+        String id = (String) jsonIntegration.get("id");
+        String name = (String) jsonIntegration.get("name");
+        boolean deleted = ifNullFalse(jsonIntegration, "deleted");
+        return new SlackIntegrationImpl(id, name, deleted);
     }
 }

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONSessionStatusParser.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONSessionStatusParser.java
@@ -1,23 +1,22 @@
 package com.ullink.slack.simpleslackapi.impl;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.ullink.slack.simpleslackapi.*;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.ullink.slack.simpleslackapi.SlackChannel;
-import com.ullink.slack.simpleslackapi.SlackPersona;
-import com.ullink.slack.simpleslackapi.SlackTeam;
-import com.ullink.slack.simpleslackapi.SlackUser;
+
+import java.util.HashMap;
+import java.util.Map;
 
 class SlackJSONSessionStatusParser {
-    private static final Logger       LOGGER   = LoggerFactory.getLogger(SlackJSONSessionStatusParser.class);
+    private static final Logger             LOGGER       = LoggerFactory.getLogger(SlackJSONSessionStatusParser.class);
 
-    private Map<String, SlackChannel> channels = new HashMap<>();
-    private Map<String, SlackUser>    users    = new HashMap<>();
+    private Map<String, SlackChannel>       channels     = new HashMap<>();
+    private Map<String, SlackUser>          users        = new HashMap<>();
+    private Map<String, SlackIntegration>   integrations = new HashMap<>();
 
     private SlackPersona              sessionPersona;
 
@@ -44,7 +43,12 @@ class SlackJSONSessionStatusParser {
         return users;
     }
 
-    public String getWebSocketURL() {
+    Map<String,SlackIntegration> getIntegrations() {
+        return integrations;
+    }
+
+    public String getWebSocketURL()
+    {
         return webSocketURL;
     }
 
@@ -72,14 +76,14 @@ class SlackJSONSessionStatusParser {
             users.put(slackUser.getId(), slackUser);
         }
 
-        JSONArray botsJson = (JSONArray) jsonResponse.get("bots");
-        if (botsJson != null) {
-            for (Object jsonObject : botsJson)
+        JSONArray integrationsJson = (JSONArray) jsonResponse.get("bots");
+        if (integrationsJson != null) {
+            for (Object jsonObject : integrationsJson)
             {
-                JSONObject jsonBot = (JSONObject) jsonObject;
-                SlackUser slackUser = SlackJSONParsingUtils.buildSlackUser(jsonBot);
-                LOGGER.debug("slack bot found : " + slackUser.getId());
-                users.put(slackUser.getId(), slackUser);
+                JSONObject jsonIntegration = (JSONObject) jsonObject;
+                SlackIntegration slackIntegration = SlackJSONParsingUtils.buildSlackIntegration(jsonIntegration);
+                LOGGER.debug("slack integration found : " + slackIntegration.getId());
+                integrations.put(slackIntegration.getId(), slackIntegration);
             }
         }
 

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackPersonaImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackPersonaImpl.java
@@ -20,10 +20,12 @@ class SlackPersonaImpl implements SlackPersona {
     final String timeZone;
     final String timeZoneLabel;
     final Integer timeZoneOffset;
+    final SlackPresence presence;
 
     SlackPersonaImpl(String id, String userName, String realName, String userMail, String userSkype, String userPhone, String userTitle,
                      boolean deleted, boolean admin, boolean owner, boolean primaryOwner, boolean restricted,
-                     boolean ultraRestricted, boolean bot, String timeZone, String timeZoneLabel, Integer timeZoneOffset) {
+                     boolean ultraRestricted, boolean bot, String timeZone, String timeZoneLabel, Integer timeZoneOffset,
+                     SlackPresence presence) {
         this.id = id;
         this.userName = userName;
         this.realName = realName;
@@ -41,6 +43,7 @@ class SlackPersonaImpl implements SlackPersona {
         this.timeZone = timeZone;
         this.timeZoneLabel = timeZoneLabel;
         this.timeZoneOffset = timeZoneOffset;
+        this.presence = presence;
     }
 
     @Override
@@ -140,6 +143,11 @@ class SlackPersonaImpl implements SlackPersona {
     public Integer getTimeZoneOffset()
     {
         return timeZoneOffset;
+    }
+
+    @Override
+    public SlackPresence getPresence() {
+        return presence;
     }
 
 }

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackUserImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackUserImpl.java
@@ -15,9 +15,10 @@ class SlackUserImpl extends SlackPersonaImpl implements SlackUser {
 
     SlackUserImpl(String id, String userName, String realName, String userMail, String userSkype, String userTitle, String userPhone,
                   boolean deleted, boolean admin, boolean owner, boolean primaryOwner, boolean restricted,
-                  boolean ultraRestricted, boolean bot, String timeZone, String timeZoneLabel, Integer timeZoneOffset)
+                  boolean ultraRestricted, boolean bot, String timeZone, String timeZoneLabel, Integer timeZoneOffset,
+                  SlackPresence slackPresence)
     {
         super(id, userName, realName, userMail, userSkype, userPhone, userTitle, deleted, admin, owner, primaryOwner,
-                restricted, ultraRestricted, bot, timeZone, timeZoneLabel, timeZoneOffset);
+                restricted, ultraRestricted, bot, timeZone, timeZoneLabel, timeZoneOffset, slackPresence);
     }
 }

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -272,6 +272,7 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
         }
 
         users = sessionParser.getUsers();
+        integrations = sessionParser.getIntegrations();
         channels = sessionParser.getChannels();
         sessionPersona = sessionParser.getSessionPersona();
         team = sessionParser.getTeam();

--- a/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestAbstractSlackSessionImpl.java
+++ b/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestAbstractSlackSessionImpl.java
@@ -27,15 +27,15 @@ public class TestAbstractSlackSessionImpl
             channels.put("channelid4",new SlackChannelImpl("channelid4", "testchannel4", "topicchannel4", "topicchannel4", false, false));
             channels.put("channelid5",new SlackChannelImpl("channelid5", "testchannel5", "topicchannel5", "topicchannel5", false, false));
 
-            users.put("userid1",new SlackUserImpl("userid1", "username1", "realname1","userid1@my.mail", "testSkype", "testPhone", "testTitle", false,false,false,false,false,false, false,"tz","tzLabel",new Integer(0)));
-            users.put("userid2",new SlackUserImpl("userid2", "username2", "realname2","userid2@my.mail", "testSkype", "testPhone", "testTitle", false,false,false,false,false,false, false,"tz","tzLabel",new Integer(0)));
-            users.put("userid3",new SlackUserImpl("userid3", "username3", "realname3","userid3@my.mail", "testSkype", "testPhone", "testTitle", true,false,false,false,false,false, false,"tz","tzLabel",new Integer(0)));
-            users.put("userid4",new SlackUserImpl("userid4", "username4", "realname4","userid4@my.mail", "testSkype", "testPhone", "testTitle", false,false,false,false,false,false, false,"tz","tzLabel",new Integer(0)));
-            users.put("userid5",new SlackUserImpl("userid5", "username5", "realname4","userid5@my.mail", "testSkype", "testPhone", "testTitle", true,false,false,false,false,false, false,"tz","tzLabel",new Integer(0)));
+            users.put("userid1",new SlackUserImpl("userid1", "username1", "realname1","userid1@my.mail", "testSkype", "testPhone", "testTitle", false,false,false,false,false,false, false,"tz","tzLabel",new Integer(0), SlackPersona.SlackPresence.ACTIVE));
+            users.put("userid2",new SlackUserImpl("userid2", "username2", "realname2","userid2@my.mail", "testSkype", "testPhone", "testTitle", false,false,false,false,false,false, false,"tz","tzLabel",new Integer(0), SlackPersona.SlackPresence.ACTIVE));
+            users.put("userid3",new SlackUserImpl("userid3", "username3", "realname3","userid3@my.mail", "testSkype", "testPhone", "testTitle", true,false,false,false,false,false, false,"tz","tzLabel",new Integer(0), SlackPersona.SlackPresence.ACTIVE));
+            users.put("userid4",new SlackUserImpl("userid4", "username4", "realname4","userid4@my.mail", "testSkype", "testPhone", "testTitle", false,false,false,false,false,false, false,"tz","tzLabel",new Integer(0), SlackPersona.SlackPresence.ACTIVE));
+            users.put("userid5",new SlackUserImpl("userid5", "username5", "realname4","userid5@my.mail", "testSkype", "testPhone", "testTitle", true,false,false,false,false,false, false,"tz","tzLabel",new Integer(0), SlackPersona.SlackPresence.ACTIVE));
 
-            users.put("botid1",new SlackUserImpl("botid1", "botname1", "real bot name 1", null, "testSkype", "testPhone", "testTitle", false,false,false,false,false,false,true,"tz","tzLabel",new Integer(0)));
-            users.put("botid2",new SlackUserImpl("botid2", "botname2", "real bot name 2", null, "testSkype", "testPhone", "testTitle", false,false,false,false,false,false,true,"tz","tzLabel",new Integer(0)));
-            users.put("botid3",new SlackUserImpl("botid3", "botname3", "real bot name 3", null, "testSkype", "testPhone", "testTitle", true,false,false,false,false,false,true,"tz","tzLabel",new Integer(0)));
+            users.put("botid1",new SlackUserImpl("botid1", "botname1", "real bot name 1", null, "testSkype", "testPhone", "testTitle", false,false,false,false,false,false,true,"tz","tzLabel",new Integer(0), SlackPersona.SlackPresence.ACTIVE));
+            users.put("botid2",new SlackUserImpl("botid2", "botname2", "real bot name 2", null, "testSkype", "testPhone", "testTitle", false,false,false,false,false,false,true,"tz","tzLabel",new Integer(0), SlackPersona.SlackPresence.ACTIVE));
+            users.put("botid3",new SlackUserImpl("botid3", "botname3", "real bot name 3", null, "testSkype", "testPhone", "testTitle", true,false,false,false,false,false,true,"tz","tzLabel",new Integer(0), SlackPersona.SlackPresence.ACTIVE));
         }
 
         @Override

--- a/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONMessageParser.java
+++ b/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONMessageParser.java
@@ -59,9 +59,9 @@ public class TestSlackJSONMessageParser {
 
             @Override
             public void connect() {
-                SlackUser user1 = new SlackUserImpl("TESTUSER1", "test user 1", "", "", "testSkype", "testPhone", "testTitle", false, false, false, false, false, false, false, "tz", "tzLabel", new Integer(0));
-                SlackUser user2 = new SlackUserImpl("TESTUSER2", "test user 2", "", "", "testSkype", "testPhone", "testTitle", false, false, false, false, false, false, false, "tz", "tzLabel", new Integer(0));
-                SlackUser user3 = new SlackUserImpl("TESTUSER3", "test user 3", "", "", "testSkype", "testPhone", "testTitle", false, false, false, false, false, false, false, "tz", "tzLabel", new Integer(0));
+                SlackUser user1 = new SlackUserImpl("TESTUSER1", "test user 1", "", "", "testSkype", "testPhone", "testTitle", false, false, false, false, false, false, false, "tz", "tzLabel", new Integer(0), SlackPersona.SlackPresence.ACTIVE);
+                SlackUser user2 = new SlackUserImpl("TESTUSER2", "test user 2", "", "", "testSkype", "testPhone", "testTitle", false, false, false, false, false, false, false, "tz", "tzLabel", new Integer(0), SlackPersona.SlackPresence.ACTIVE);
+                SlackUser user3 = new SlackUserImpl("TESTUSER3", "test user 3", "", "", "testSkype", "testPhone", "testTitle", false, false, false, false, false, false, false, "tz", "tzLabel", new Integer(0), SlackPersona.SlackPresence.ACTIVE);
                 users.put(user1.getId(), user1);
                 users.put(user2.getId(), user2);
                 users.put(user3.getId(), user3);

--- a/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONSessionStatusParser.java
+++ b/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONSessionStatusParser.java
@@ -1,10 +1,12 @@
 package com.ullink.slack.simpleslackapi.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
+
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestSlackJSONSessionStatusParser
 {
@@ -36,5 +38,10 @@ public class TestSlackJSONSessionStatusParser
         assertThat(parser.getTeam().getId()).isEqualTo("TEAM");
         assertThat(parser.getTeam().getName()).isEqualTo("Example Team");
         assertThat(parser.getTeam().getDomain()).isEqualTo("example");
+
+        assertThat(parser.getIntegrations().get("INTEGRATION1").getName()).isEqualTo("bot1");
+        assertThat(parser.getIntegrations().get("INTEGRATION1").isDeleted()).isEqualTo(false);
+        assertThat(parser.getIntegrations().get("INTEGRATION2").getName()).isEqualTo("bot2");
+        assertThat(parser.getIntegrations().get("INTEGRATION2").isDeleted()).isEqualTo(true);
     }
 }

--- a/sources/src/test/resources/test_json.json
+++ b/sources/src/test/resources/test_json.json
@@ -272,5 +272,17 @@
       "type": "service"
     }
  },
+  "bots": [
+    {
+      "id": "INTEGRATION1",
+      "deleted": false,
+      "name": "bot1"
+    },
+    {
+      "id": "INTEGRATION2",
+      "deleted": true,
+      "name": "bot2"
+    }
+  ],
   "url": "wss:\/\/mywebsocketurl"
 }


### PR DESCRIPTION
This pull request fixes issue with user list and adds integrations support functionality.

**Issue**
While parsing rtm.start response in SlackJSONSessionStatusParser both users and bots arrays are merged into users array which cause mix of incompatible types because bots array contains slack integrations (probably SlackJSONSessionStatusParser author was confused by array name).
Here you may see issue example:
``` java
session.getUsers().stream().forEach(slackUser -> {
	System.out.println(slackUser.getUserName() + " " + session.getPresence(slackUser));
});
```
Following code will fail as _session.getUsers()_ will also return integrations which may not be associated with Slack users.
Here is example of SlackUser instance which was created from Slack Integration (bots array):

> SlackUserImpl{id='B0UH998N6', userName='Konsus', realName='null', userMail='', userSkype='', userPhone='', userTitle='', isDeleted=false', isAdmin=false', isOwner=false', isPrimaryOwner=false', isRestricted=false', isUltraRestricted=false, timeZone=null, timeZoneLabel=null, timeZoneOffset=null}

As you can see userName contains upper case letter which is not allowed for slack user names. The reason is that this SlackUser instance was created from integration record where _name_ filed represent name of integration and not associated with slack user.

**Fix**
To fix this issue I decided to introduce new entity _SlackIntegration_ and use bots array as a provider of SlackIntegrations. Now users can retrieve all available integrations by calling
`session.getIntegrations()`
Meanwhile _session.getUsers()_ returns only real users and bot users without integration instances.