### PR TITLE
override Endpoint#onError and log error when called

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -296,6 +296,11 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
                     session.addMessageHandler(handler);
                 }
 
+                @Override
+                public void onError(Session session, Throwable thr) {
+                    LOGGER.error("Endpoint#onError called", thr);
+                }
+
             }, URI.create(wssurl));
         }
         catch (DeploymentException e) {


### PR DESCRIPTION
motivation:

when user registered listener throws, the exception is swallowed by the default
impl of Endpoint#onError (no-op)

changes:

* override Endpoint#onError in SlackWebSocketSessionImpl#connectImpl, log error