### PR TITLE
ensure all listeners are called, even if exception is thrown from one

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -209,7 +209,11 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
 
         private <E extends SlackEvent, L extends SlackEventListener<E>> void dispatchImpl(E event, List<L> listeners) {
             for (L listener : listeners) {
-                listener.onEvent(event, SlackWebSocketSessionImpl.this);
+                try {
+                    listener.onEvent(event, SlackWebSocketSessionImpl.this);
+                } catch (Throwable thr) {
+                    LOGGER.error("caught exception in dispatchImpl", thr);
+                }
             }
         }
     }


### PR DESCRIPTION
motivation:

currently, if you add two listeners to a message type, and the first throws,
the second will not be called.

changes:

* wrap the body of the loop iterating the listeners with try-catch
* catch Throwable and log as error