### PR TITLE
log type of UNKNOWN events when throwing on them

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -203,7 +203,7 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
                     dispatchImpl((UserTyping) event, userTypingListener);
                     break;
                 case UNKNOWN:
-                    throw new IllegalArgumentException("event not handled " + event);
+                    throw new IllegalArgumentException("event of type " + event.getEventType() + " not handled: " + event);
             }
         }
 


### PR DESCRIPTION
motivation:

when an unknown event occurs, this is logged:

11:56:14.337 [Grizzly(2)] ERROR c.u.s.s.i.SlackWebSocketSessionImpl - Endpoint#onError called
java.lang.IllegalArgumentException: event not handled com.ullink.slack.simpleslackapi.events.SlackEvent$1@70a36547
	at com.ullink.slack.simpleslackapi.impl.SlackWebSocketSessionImpl$EventDispatcher.dispatch(SlackWebSocketSessionImpl.java:206) ~[simple-slack-api-f1aacf20c28cfc4b96aa29067f7f0faa5594c664.jar:na]

not useful without the event type

changes:

* log event type in exception message