### PR TITLE
Fix sample for filtering messages by a user

### DIFF
--- a/samples/events/src/main/java/events/ListeningToMessageEvents.java
+++ b/samples/events/src/main/java/events/ListeningToMessageEvents.java
@@ -57,7 +57,7 @@ public class ListeningToMessageEvents
                 // I can filter out messages coming from other users
                 SlackUser myInterestingUser = session1.findUserByUserName("gueststar");
 
-                if (!myInterestingUser.getId().equals(event.getSender())) {
+                if (!myInterestingUser.getId().equals(event.getSender().getId())) {
                     return;
                 }
 


### PR DESCRIPTION
The example was comparing the ID of the user to the sender of the message, instead of the ID of the sender.