### PR TITLE
Guava is removed from dependencies

### DIFF
--- a/sources/build.gradle
+++ b/sources/build.gradle
@@ -97,6 +97,11 @@ def pomConfig = {
             email 'morfeusys@gmail.com'
             url 'https://github.com/Morfeusys'
         }
+        contributor {
+            name 'Bahadir Akin'
+            email 'bhdrkn@gmail.com'
+            url 'https://github.com/bhdrkn'
+        }
     }
     scm {
         connection 'scm:git:git@github.com:Ullink/simple-slack-api.git'
@@ -192,7 +197,6 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.7'
     compile 'org.apache.httpcomponents:httpclient:4.4'
     compile 'org.apache.httpcomponents:httpmime:4.4'
-    compile 'com.google.guava:guava:18.0'
     compile 'ch.qos.logback:logback-classic:1.1.3'
     compile 'org.threeten:threetenbp:1.3.1'
     compile 'org.glassfish.tyrus.bundles:tyrus-standalone-client:1.13', optional

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -1,6 +1,5 @@
 package com.ullink.slack.simpleslackapi.impl;
 
-import com.google.common.io.CharStreams;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -10,6 +9,7 @@ import com.ullink.slack.simpleslackapi.events.*;
 import com.ullink.slack.simpleslackapi.impl.SlackChatConfiguration.Avatar;
 import com.ullink.slack.simpleslackapi.listeners.SlackEventListener;
 import com.ullink.slack.simpleslackapi.replies.*;
+import com.ullink.slack.simpleslackapi.utils.ReaderUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
@@ -675,7 +675,7 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
             builder.addBinaryBody("file",fileContent, ContentType.DEFAULT_BINARY,fileName);
             request.setEntity(builder.build());
             HttpResponse response = client.execute(request);
-            String jsonResponse = CharStreams.toString(new InputStreamReader(response.getEntity().getContent()));
+            String jsonResponse = ReaderUtils.readAll(new InputStreamReader(response.getEntity().getContent()));
             LOGGER.debug("PostMessage return: " + jsonResponse);
             ParsedSlackReply reply = SlackJSONReplyParser.decode(parseObject(jsonResponse),this);
             handle.setReply(reply);

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/utils/ReaderUtils.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/utils/ReaderUtils.java
@@ -1,0 +1,50 @@
+package com.ullink.slack.simpleslackapi.utils;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.CharBuffer;
+
+/**
+ * Holds utilities for {@link java.io.Reader}s.
+ */
+public final class ReaderUtils
+{
+
+    /**
+     * Size of char buffer that is read to.
+     */
+    private static final int BUFFER_SIZE = 1024; // 1KB
+
+    /**
+     * Reads everything from reader and returns as string.
+     * @param reader the object read from
+     * @return a string containing all the information
+     */
+    public static String readAll(final Reader reader) throws IOException
+    {
+        if(reader == null)
+        {
+            throw new NullPointerException("Reader is null...");
+        }
+
+        final StringBuilder stringBuilder = new StringBuilder();
+        copy(reader, stringBuilder);
+        return stringBuilder.toString();
+
+    }
+
+    private static void copy(final Reader from, final Appendable to) throws IOException
+    {
+        final CharBuffer charBuffer = CharBuffer.allocate(BUFFER_SIZE);
+        while (from.read(charBuffer) != -1) {
+            charBuffer.flip();
+            to.append(charBuffer);
+            charBuffer.clear();
+        }
+    }
+
+    private ReaderUtils()
+    {
+
+    }
+}

--- a/sources/src/test/java/com/ullink/slack/simpleslackapi/utils/ReaderUtilsTest.java
+++ b/sources/src/test/java/com/ullink/slack/simpleslackapi/utils/ReaderUtilsTest.java
@@ -1,0 +1,29 @@
+package com.ullink.slack.simpleslackapi.utils;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ReaderUtilsTest {
+    
+    @Test
+    public void readAll() throws Exception {
+        // Given
+        final String example = "this is a test!";
+        final InputStream inputStream = new ByteArrayInputStream(example.getBytes(Charset.forName("UTF-8")));
+
+        // When
+        final String readResult = ReaderUtils.readAll(new InputStreamReader(inputStream));
+
+        // Then
+        assertThat(readResult, is(equalTo(example)));
+    }
+
+}


### PR DESCRIPTION
Guava is only used for converting reader to String.
A new utility is added to cover this case and
guava dependency is removed.

https://github.com/Ullink/simple-slack-api/issues/126