### PR TITLE
Fix channel parsing from channel_created event

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONMessageParser.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONMessageParser.java
@@ -306,8 +306,14 @@ class SlackJSONMessageParser {
     private static SlackChannel parseChannelDescription(JsonObject channelJSONObject) {
         String id = GsonHelper.getStringOrNull(channelJSONObject.get("id"));
         String name = GsonHelper.getStringOrNull(channelJSONObject.get("name"));
-        String topic = GsonHelper.getStringOrNull(channelJSONObject.get("topic").getAsJsonObject().get("value"));
-        String purpose = GsonHelper.getStringOrNull((channelJSONObject.get("purpose").getAsJsonObject().get("value")));
+        String topic = null;
+        String purpose = null;
+        if (channelJSONObject.has("topic")) {
+            topic = GsonHelper.getStringOrNull(channelJSONObject.get("topic").getAsJsonObject().get("value"));
+        }
+        if (channelJSONObject.has("purpose")) {
+            purpose = GsonHelper.getStringOrNull((channelJSONObject.get("purpose").getAsJsonObject().get("value")));
+        }
         boolean isArchived = GsonHelper.getBooleanOrDefaultValue(channelJSONObject.get("is_archived"), false);
         return new SlackChannelImpl(id, name, topic, purpose, id.startsWith("D"),false, isArchived);
     }

--- a/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONMessageParser.java
+++ b/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONMessageParser.java
@@ -24,7 +24,7 @@ public class TestSlackJSONMessageParser {
     private static final String TEST_DELETED_MESSAGE = "{\"type\":\"message\",\"channel\":\"TESTCHANNEL1\",\"user\":\"TESTUSER1\",\"text\":\"Test text 1\",\"ts\":\"1413187521.000005\", \"subtype\": \"message_deleted\", \"deleted_ts\": \"1358878749.000002\"}";
     private static final String TEST_UPDATED_MESSAGE = "{\"type\":\"message\",\"channel\":\"TESTCHANNEL1\",\"text\":\"Test text 1\",\"ts\":\"1358878755.001234\", \"subtype\": \"message_changed\", \"message\": {\"type\": \"message\", \"user\": \"TESTUSER1\", \"text\": \"newtext\", \"ts\": \"1413187521.000005\", \"edited\": { \"user\": \"TESTUSER1\", \"ts\":\"1358878755.001234\"}}}";
 
-    private static final String TEST_CHANNEL_CREATED = "{\"type\":\"channel_created\",\"channel\": { \"id\": \"NEWCHANNEL\", \"name\": \"new channel\", \"creator\": \"TESTUSER1\", \"topic\": {\"value\": \"Catz Wid Hatz\"}, \"purpose\": {\"value\": \"To post pictures of de Catz wid dem Hatz On\"}}}";
+    private static final String TEST_CHANNEL_CREATED = "{\"type\":\"channel_created\",\"channel\": { \"id\": \"NEWCHANNEL\", \"name\": \"new channel\", \"creator\": \"TESTUSER1\"}}";
     private static final String TEST_CHANNEL_DELETED = "{\"type\":\"channel_deleted\",\"channel\": \"TESTCHANNEL1\"}";
 
     private static final String TEST_CHANNEL_ARCHIVED = "{\"type\":\"channel_archive\",\"channel\": \"TESTCHANNEL1\",\"user\":\"TESTUSER1\"}";
@@ -278,8 +278,8 @@ public class TestSlackJSONMessageParser {
         Assertions.assertThat(slackChannelCreated.getCreator().getId()).isEqualTo("TESTUSER1");
         Assertions.assertThat(slackChannelCreated.getSlackChannel().getName()).isEqualTo("new channel");
         Assertions.assertThat(slackChannelCreated.getSlackChannel().getId()).isEqualTo("NEWCHANNEL");
-        Assertions.assertThat(slackChannelCreated.getSlackChannel().getTopic()).isEqualTo("Catz Wid Hatz");
-        Assertions.assertThat(slackChannelCreated.getSlackChannel().getPurpose()).isEqualTo("To post pictures of de Catz wid dem Hatz On");
+        Assertions.assertThat(slackChannelCreated.getSlackChannel().getTopic()).isNull();
+        Assertions.assertThat(slackChannelCreated.getSlackChannel().getPurpose()).isNull();
         Assertions.assertThat(slackChannelCreated.getSlackChannel().isArchived()).isEqualTo(false);
     }
 


### PR DESCRIPTION
The [channel_created](https://api.slack.com/events/channel_created) event
doesn't contain a channel topic or purpose, unlike the other channel-related events
(channel_joined, group_joined). This was causing a NPE when trying to parse the
channel object out of the event body:

```
16:36:08.710 [Grizzly(1)] DEBUG c.u.s.s.i.SlackWebSocketSessionImpl - receiving from websocket {"type":"channel_created","channel":{"id":"CXXXXXXX","is_channel":true,"name":"XXXX","created":1477067768,"creator":"UXXXXXXX","is_shared":false,"is_org_shared":false},"event_ts":"1477067768.798038"}
16:36:08.712 [Grizzly(1)] ERROR c.u.s.s.i.SlackWebSocketSessionImpl - Endpoint#onError called
java.lang.NullPointerException: null
        at com.ullink.slack.simpleslackapi.impl.SlackJSONMessageParser.parseChannelDescription(SlackJSONMessageParser.java:309)
        at com.ullink.slack.simpleslackapi.impl.SlackJSONMessageParser.extractChannelCreatedEvent(SlackJSONMessageParser.java:155)
        at com.ullink.slack.simpleslackapi.impl.SlackJSONMessageParser.decode(SlackJSONMessageParser.java:68)
        at com.ullink.slack.simpleslackapi.impl.SlackWebSocketSessionImpl.onMessage(SlackWebSocketSessionImpl.java:854)
        at com.ullink.slack.simpleslackapi.impl.SlackWebSocketSessionImpl.onMessage(SlackWebSocketSessionImpl.java:41)
        at org.glassfish.tyrus.core.TyrusSession.notifyMessageHandlers(TyrusSession.java:562)
        at org.glassfish.tyrus.core.TyrusEndpointWrapper.onMessage(TyrusEndpointWrapper.java:812)
        at org.glassfish.tyrus.core.TyrusWebSocket.onMessage(TyrusWebSocket.java:200)
        ...
```

This change ensures that we don't attempt to extract topic or purpose out of channel
json blobs that don't have those fields, setting nulls into the SlackChannel object
instead.

I believe this helps address #141
