### PR TITLE
fixup build.gradle to generate a correct ipr file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ apply plugin: 'idea'
 
 subprojects {
     apply plugin: 'java'
+    apply plugin: 'idea'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
without this, running `./gradlew idea` generates an ipr file which causes intellij to be unable to parse the sources