### PR TITLE
Add "item_user" field to reactions

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/events/ReactionAdded.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/events/ReactionAdded.java
@@ -9,6 +9,7 @@ public interface ReactionAdded extends SlackEvent {
     String getEmojiName();
     SlackChannel getChannel();
     SlackUser getUser();
+    SlackUser getItemUser();
     String getMessageID();
     String getFileID();
     String getFileCommentID();

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/events/ReactionRemoved.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/events/ReactionRemoved.java
@@ -8,8 +8,9 @@ public interface ReactionRemoved extends SlackEvent {
     String getEmojiName();
     SlackChannel getChannel();
     SlackUser getUser();
+    SlackUser getItemUser();
     String getMessageID();
     String getFileID();
     String getFileCommentID();
-  
+
 }

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/ReactionAddedImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/ReactionAddedImpl.java
@@ -11,12 +11,14 @@ public class ReactionAddedImpl implements ReactionAdded {
     private final String messageID;
     private final SlackChannel channel;
     private final SlackUser user;
+    private final SlackUser itemUser;
     private final String fileID;
     private final String fileCommentID;
 
-    public ReactionAddedImpl(String emojiName, SlackUser user, SlackChannel channel, String messageID, String fileID, String fileCommentID) {
+    public ReactionAddedImpl(String emojiName, SlackUser user, SlackUser itemUser, SlackChannel channel, String messageID, String fileID, String fileCommentID) {
         this.emojiName = emojiName;
         this.user = user;
+        this.itemUser = itemUser;
         this.channel = channel;
         this.messageID = messageID;
         this.fileID = fileID;
@@ -51,6 +53,11 @@ public class ReactionAddedImpl implements ReactionAdded {
     @Override
     public SlackUser getUser() {
         return user;
+    }
+
+    @Override
+    public SlackUser getItemUser() {
+        return itemUser;
     }
 
     @Override

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/ReactionRemovedImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/ReactionRemovedImpl.java
@@ -9,13 +9,15 @@ public class ReactionRemovedImpl implements ReactionRemoved{
     private final String emojiName;
     private final SlackChannel channel;
     private final SlackUser user;
+    private final SlackUser itemUser;
     private final String messageID;
     private final String fileID;
     private final String fileCommentID;
 
-    public ReactionRemovedImpl(String emojiName, SlackUser user, SlackChannel channel, String messageID, String fileID, String fileCommentID) {
+    public ReactionRemovedImpl(String emojiName, SlackUser user, SlackUser itemUser, SlackChannel channel, String messageID, String fileID, String fileCommentID) {
         this.emojiName = emojiName;
         this.user = user;
+        this.itemUser = itemUser;
         this.channel = channel;
         this.messageID = messageID;
         this.fileID = fileID;
@@ -50,6 +52,11 @@ public class ReactionRemovedImpl implements ReactionRemoved{
     @Override
     public SlackUser getUser() {
         return user;
+    }
+
+    @Override
+    public SlackUser getItemUser() {
+        return itemUser;
     }
 
     @Override

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONMessageParser.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONMessageParser.java
@@ -247,7 +247,7 @@ class SlackJSONMessageParser {
     }
 
     private final static String COMMENT_PLACEHOLDER = "> and commented:";
-    
+
 
      private static void parseSlackFileFromRaw(JsonObject rawFile, SlackFile file) {
         file.setId(GsonHelper.getStringOrNull(rawFile.get("id")));
@@ -275,7 +275,7 @@ class SlackJSONMessageParser {
         file.setPermalink(GsonHelper.getStringOrNull(rawFile.get("permalink")));
         file.setPermalinkPublic(GsonHelper.getStringOrNull(rawFile.get("permalink_public")));
     }
-  
+
     private static SlackMessagePostedImpl parseMessagePublishedWithFile(JsonObject obj, SlackChannel channel, String ts, SlackSession slackSession)
     {
         SlackFile file = new SlackFile();
@@ -283,23 +283,23 @@ class SlackJSONMessageParser {
             JsonObject rawFile = obj.get("file").getAsJsonObject();
 	        parseSlackFileFromRaw(rawFile, file);
         }
-        
+
         String text = GsonHelper.getStringOrNull(obj.get("text"));
         String subtype = GsonHelper.getStringOrNull(obj.get("subtype"));
 
         String comment = null;
-        
+
         int idx = text.indexOf(COMMENT_PLACEHOLDER);
-        
+
         if (idx != -1) {
             comment = text.substring(idx + COMMENT_PLACEHOLDER.length());
         }
         file.setComment(comment);
-        
+
         String userId = GsonHelper.getStringOrNull(obj.get("user"));
-        
+
         SlackUser user = slackSession.findUserById(userId);
-        
+
         return new SlackMessagePostedImpl(text, user, user, channel, ts,file,obj.toString(), SlackMessagePosted.MessageSubType.fromCode(subtype));
     }
 
@@ -328,7 +328,8 @@ class SlackJSONMessageParser {
         String channelId = GsonHelper.getStringOrNull(item.get("channel"));
         SlackChannel channel = (channelId != null) ? slackSession.findChannelById(channelId) : null;
         SlackUser user = slackSession.findUserById(GsonHelper.getStringOrNull(obj.get("user")));
-        return new ReactionAddedImpl(emojiName, user, channel, messageId, fileId, fileCommentId);
+        SlackUser itemUser = slackSession.findUserById(GsonHelper.getStringOrNull(obj.get("item_user")));
+        return new ReactionAddedImpl(emojiName, user, itemUser, channel, messageId, fileId, fileCommentId);
     }
 
     private static SlackUserChange extractUserChangeEvent(JsonObject obj) {
@@ -364,7 +365,8 @@ class SlackJSONMessageParser {
         String channelId = GsonHelper.getStringOrNull(item.get("channel"));
         SlackChannel channel = (channelId != null) ? slackSession.findChannelById(channelId) : null;
         SlackUser user = slackSession.findUserById(GsonHelper.getStringOrNull(obj.get("user")));
-        return new ReactionRemovedImpl(emojiName, user, channel, messageId, fileId, fileCommentId);
+        SlackUser itemUser = slackSession.findUserById(GsonHelper.getStringOrNull(obj.get("item_user")));
+        return new ReactionRemovedImpl(emojiName, user, itemUser, channel, messageId, fileId, fileCommentId);
     }
 
     private static UserTyping extractUserTypingEvent(SlackSession slackSession, JsonObject obj) {
@@ -419,7 +421,7 @@ class SlackJSONMessageParser {
 	    }
 	    String timestamp = GsonHelper.getStringOrNull(obj.get("event_ts"));
 
-        return new PinAddedImpl(sender, channel, timestamp, file, message);       
+        return new PinAddedImpl(sender, channel, timestamp, file, message);
     }
 
     private static Map<String, Integer> extractReactionsFromMessageJSON(JsonObject obj) {


### PR DESCRIPTION
This commit is a simple extension to the JSON parsing already in place
for reaction added/removed events. The "item_user" field already exists
in Slack's API response, seen [here](https://api.slack.com/events/reaction_removed) and [here](https://api.slack.com/events/reaction_added).