### PR TITLE
Add functionality for a refresh of channel if there is a Slack Channel Joined event.

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -920,6 +920,11 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
                 SlackChannelCreated slackChannelCreated = (SlackChannelCreated) slackEvent;
                 channels.put(slackChannelCreated.getSlackChannel().getId(), slackChannelCreated.getSlackChannel());
             }
+            if (slackEvent instanceof SlackChannelJoined)
+            {
+                SlackChannelJoined slackChannelJoined = (SlackChannelJoined) slackEvent;
+                channels.put(slackChannelJoined.getSlackChannel().getId(), slackChannelJoined.getSlackChannel());
+            }
             if (slackEvent instanceof SlackGroupJoined)
             {
                 SlackGroupJoined slackGroupJoined = (SlackGroupJoined) slackEvent;


### PR DESCRIPTION
For example, if a bot is listening for commands in a particular channel; a user joins a channel and tries to interact with the bot who uses this Slack client would not recognize that this user is a member of this channel since there was no immediate update to the list of users in the channel.