### PR TITLE
Add 'send file to user' feature.

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSession.java
@@ -67,6 +67,10 @@ public interface SlackSession {
 
     SlackMessageHandle<SlackMessageReply> sendFile(SlackChannel channel, byte [] data, String fileName);
 
+    SlackMessageHandle<SlackMessageReply> sendFileToUser(SlackUser user, byte [] data, String fileName);
+
+    SlackMessageHandle<SlackMessageReply> sendFileToUser(String userName, byte [] data, String fileName);
+
     SlackMessageHandle<SlackMessageReply> sendMessageToUser(SlackUser user, SlackPreparedMessage preparedMessage);
 
     SlackMessageHandle<SlackMessageReply> sendMessageToUser(SlackUser user, String message, SlackAttachment attachment);

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSessionWrapper.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackSessionWrapper.java
@@ -179,6 +179,18 @@ public class SlackSessionWrapper implements SlackSession
         return delegate.sendFile(channel, data, fileName);
     }
 
+    @Override
+    public SlackMessageHandle<SlackMessageReply> sendFileToUser(SlackUser user, byte[] data, String fileName)
+    {
+        return delegate.sendFileToUser(user, data, fileName);
+    }
+
+    @Override
+    public SlackMessageHandle<SlackMessageReply> sendFileToUser(String userName, byte[] data, String fileName)
+    {
+        return delegate.sendFileToUser(userName, data, fileName);
+    }
+
     @Override public SlackMessageHandle<SlackMessageReply> sendMessageToUser(SlackUser user, SlackPreparedMessage preparedMessage)
     {
         return delegate.sendMessageToUser(user, preparedMessage);

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -521,6 +521,17 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
     }
 
     @Override
+    public SlackMessageHandle<SlackMessageReply> sendFileToUser(String userName, byte[] data, String fileName) {
+        return sendFileToUser(findUserByUserName(userName), data, fileName);
+    }
+
+    @Override
+    public SlackMessageHandle<SlackMessageReply> sendFileToUser(SlackUser user, byte[] data, String fileName) {
+        SlackChannel iMChannel = getIMChannelForUser(user);
+        return sendFile(iMChannel, data, fileName);
+    }
+
+    @Override
     public SlackMessageHandle<SlackMessageReply> sendFile(SlackChannel channel, byte[] data, String fileName) {
         SlackMessageHandleImpl<SlackMessageReply> handle = new SlackMessageHandleImpl<>(getNextMessageId());
         Map<String, String> arguments = new HashMap<>();

--- a/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestAbstractSlackSessionImpl.java
+++ b/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestAbstractSlackSessionImpl.java
@@ -75,6 +75,18 @@ public class TestAbstractSlackSessionImpl
         }
 
         @Override
+        public SlackMessageHandle<SlackMessageReply> sendFileToUser(SlackUser user, byte[] data, String fileName)
+        {
+            return null;
+        }
+
+        @Override
+        public SlackMessageHandle<SlackMessageReply> sendFileToUser(String userName, byte[] data, String fileName)
+        {
+            return null;
+        }
+
+        @Override
         public SlackMessageHandle<SlackMessageReply> sendMessageToUser(SlackUser user, SlackPreparedMessage preparedMessage) {
             return null;
         }

--- a/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONMessageParser.java
+++ b/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackJSONMessageParser.java
@@ -116,6 +116,18 @@ public class TestSlackJSONMessageParser {
             }
 
             @Override
+            public SlackMessageHandle<SlackMessageReply> sendFileToUser(SlackUser user, byte[] data, String fileName)
+            {
+                return null;
+            }
+
+            @Override
+            public SlackMessageHandle<SlackMessageReply> sendFileToUser(String userName, byte[] data, String fileName)
+            {
+                return null;
+            }
+
+            @Override
             public SlackMessageHandle<SlackMessageReply> sendMessageToUser(SlackUser user, SlackPreparedMessage preparedMessage) {
                 return null;
             }


### PR DESCRIPTION
This pull request adds two overloaded 'sendFile' methods to SlackSession: one that accepts **SlackUser** and another that accepts **username as String**.