### PR TITLE
Added ability to start/reply to threads

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackPreparedMessage.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackPreparedMessage.java
@@ -10,12 +10,16 @@ public class SlackPreparedMessage {
     private final boolean unfurl;
     private final boolean linkNames;
     private final SlackAttachment[] attachments;
+    private final String threadTimestamp;
+    private final boolean replyBroadcast;
 
-    private SlackPreparedMessage(String message, boolean unfurl, boolean linkNames, SlackAttachment[] attachments) {
+    private SlackPreparedMessage(String message, boolean unfurl, boolean linkNames, SlackAttachment[] attachments, String threadTimestamp, boolean replyBroadcast) {
         this.message = message;
         this.unfurl = unfurl;
         this.linkNames = linkNames;
         this.attachments = attachments;
+        this.threadTimestamp = threadTimestamp;
+        this.replyBroadcast = replyBroadcast;
     }
 
     public String getMessage() {
@@ -34,11 +38,21 @@ public class SlackPreparedMessage {
         return attachments;
     }
 
+    public String getThreadTimestamp() {
+        return threadTimestamp;
+    }
+
+    public boolean isReplyBroadcast() {
+        return replyBroadcast;
+    }
+
     public static class Builder {
         String message;
         boolean unfurl;
         boolean linkNames;
         List<SlackAttachment> attachments;
+        String threadTimestamp;
+        boolean replyBroadcast;
 
         public Builder() {
             this.attachments = new ArrayList<>();
@@ -80,12 +94,24 @@ public class SlackPreparedMessage {
             return this;
         }
 
+        public Builder withThreadTimestamp(String threadTimestamp) {
+            this.threadTimestamp = threadTimestamp;
+            return this;
+        }
+
+        public Builder withReplyBroadcast(boolean replyBroadcast) {
+            this.replyBroadcast = replyBroadcast;
+            return this;
+        }
+
         public SlackPreparedMessage build() {
             return new SlackPreparedMessage(
                     message,
                     unfurl,
                     linkNames,
-                    attachments.toArray(new SlackAttachment[]{}));
+                    attachments.toArray(new SlackAttachment[]{}),
+                    threadTimestamp,
+                    replyBroadcast);
         }
     }
 

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/events/SlackMessagePosted.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/events/SlackMessagePosted.java
@@ -1,12 +1,13 @@
 package com.ullink.slack.simpleslackapi.events;
 
 import com.ullink.slack.simpleslackapi.SlackAttachment;
-import java.util.Map;
 import com.ullink.slack.simpleslackapi.SlackBot;
 import com.ullink.slack.simpleslackapi.SlackChannel;
 import com.ullink.slack.simpleslackapi.SlackFile;
 import com.ullink.slack.simpleslackapi.SlackUser;
+
 import java.util.ArrayList;
+import java.util.Map;
 
 public interface SlackMessagePosted extends SlackMessageEvent {
     enum MessageSubType {
@@ -33,6 +34,7 @@ public interface SlackMessagePosted extends SlackMessageEvent {
         MESSAGE_DELETED("message_deleted"),
         PINNED_ITEM("pinned_item"),
         UNPINNED_ITEM("unpinned_item"),
+        MESSAGE_REPLIED("message_replied"),
         UNKNOWN("");
 
         String code;
@@ -72,4 +74,6 @@ public interface SlackMessagePosted extends SlackMessageEvent {
     MessageSubType getMessageSubType();
 
     ArrayList<SlackAttachment> getAttachments();
+
+    String getThreadTimestamp();
 }

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackMessagePostedImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackMessagePostedImpl.java
@@ -1,15 +1,11 @@
 package com.ullink.slack.simpleslackapi.impl;
 
-import com.ullink.slack.simpleslackapi.SlackAttachment;
-import java.util.ArrayList;
-import java.util.Map;
-
-import com.ullink.slack.simpleslackapi.SlackBot;
-import com.ullink.slack.simpleslackapi.SlackChannel;
-import com.ullink.slack.simpleslackapi.SlackFile;
-import com.ullink.slack.simpleslackapi.SlackUser;
+import com.ullink.slack.simpleslackapi.*;
 import com.ullink.slack.simpleslackapi.events.SlackEventType;
 import com.ullink.slack.simpleslackapi.events.SlackMessagePosted;
+
+import java.util.ArrayList;
+import java.util.Map;
 
 class SlackMessagePostedImpl implements SlackMessagePosted {
     private String       messageContent;
@@ -17,6 +13,7 @@ class SlackMessagePostedImpl implements SlackMessagePosted {
     private SlackBot     bot;
     private SlackChannel channel;
     private String       timestamp;
+    private String       threadTimestamp;
     private SlackFile    slackFile;
     private String   jsonSource;
     private MessageSubType msgSubType;
@@ -33,7 +30,7 @@ class SlackMessagePostedImpl implements SlackMessagePosted {
         this.msgSubType = msgSubType;
     }
 
-    SlackMessagePostedImpl(String messageContent, SlackBot bot, SlackUser user, SlackChannel channel, String timestamp, SlackFile slackFile, String jsonSource, MessageSubType msgSubType)
+    SlackMessagePostedImpl(String messageContent, SlackBot bot, SlackUser user, SlackChannel channel, String timestamp, SlackFile slackFile, String jsonSource, MessageSubType msgSubType, String threadTimestamp)
     {
         this.channel = channel;
         this.messageContent = messageContent;
@@ -43,6 +40,7 @@ class SlackMessagePostedImpl implements SlackMessagePosted {
         this.jsonSource = jsonSource;
         this.slackFile = slackFile;
         this.msgSubType = msgSubType;
+        this.threadTimestamp = threadTimestamp;
     }
 
     @Override
@@ -121,5 +119,10 @@ class SlackMessagePostedImpl implements SlackMessagePosted {
     }
 
     @Override public ArrayList<SlackAttachment> getAttachments() { return attachments; }
+
+    @Override
+    public String getThreadTimestamp() {
+        return threadTimestamp;
+    }
 }
 

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -515,6 +515,13 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
         {
             arguments.put("link_names", "1");
         }
+        if(preparedMessage.getThreadTimestamp() != null) {
+            arguments.put("thread_ts", preparedMessage.getThreadTimestamp());
+
+            if(preparedMessage.isReplyBroadcast()) {
+                arguments.put("reply_broadcast", "true");
+            }
+        }
 
         postSlackCommand(arguments, CHAT_POST_MESSAGE_COMMAND, handle);
         return handle;


### PR DESCRIPTION
With this PR, bots will be able to start threads / reply to threads.

Messages from threads are message events but with a "thread_ts" property to attach the message to a parent. Each message from the thread has the same "thread_ts" value.

I added this property (and the "reply_broadcast" property used to also display the message in the parent channel) in the SlackPreparedMessage, so this should not break the current state of the API.

I chose not to handle the hidden "message_replied" event. I used SlackEvent.UNKNOWN_EVENT as a fallback so no error is raised, but it could be implemented in a later stage.

Also, there is a bug referencing this: #172.

Slack API reference doc : https://api.slack.com/docs/message-threading