### PR TITLE
Allow no proxy in SlackSessionFactoryBuilder

### DIFF
--- a/samples/connection/src/main/java/com/ullink/slack/simpleslackapi/samples/connection/SlackDirectConnectionWithBuilder.java
+++ b/samples/connection/src/main/java/com/ullink/slack/simpleslackapi/samples/connection/SlackDirectConnectionWithBuilder.java
@@ -1,0 +1,19 @@
+package com.ullink.slack.simpleslackapi.samples.connection;
+
+import com.ullink.slack.simpleslackapi.SlackSession;
+import com.ullink.slack.simpleslackapi.impl.SlackSessionFactory;
+
+import java.io.IOException;
+
+/**
+ * This sample code is creating a Slack session and is connecting to slack. To get some more details on
+ * how to get a token, please have a look here : https://api.slack.com/bot-users
+ */
+public class SlackDirectConnectionWithBuilder
+{
+    public static void main(String[] args) throws IOException
+    {
+        SlackSession session = SlackSessionFactory.getSlackSessionBuilder("my-bot-auth-token").build();
+        session.connect();
+    }
+}

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -253,20 +253,22 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
         this.authToken = authToken;
         this.reconnectOnDisconnection = reconnectOnDisconnection;
         this.heartbeat = heartbeat != 0 ? unit.toMillis(heartbeat) : 30000;
-        this.webSocketContainerProvider = webSocketContainerProvider != null ? webSocketContainerProvider : new DefaultWebSocketContainerProvider(null, 0, null, null);
+        this.webSocketContainerProvider = webSocketContainerProvider != null ? webSocketContainerProvider : new DefaultWebSocketContainerProvider(null, -1, null, null);
         addInternalListeners();
     }
 
     SlackWebSocketSessionImpl(WebSocketContainerProvider webSocketContainerProvider, String authToken, Proxy.Type proxyType, String proxyAddress, int proxyPort, String proxyUser, String proxyPassword, boolean reconnectOnDisconnection, long heartbeat, TimeUnit unit) {
         this.authToken = authToken;
-        this.proxyAddress = proxyAddress;
-        this.proxyPort = proxyPort;
-        this.proxyHost = new HttpHost(proxyAddress, proxyPort);
+        if (proxyType != null && proxyType != Proxy.Type.DIRECT) {
+            this.proxyAddress = proxyAddress;
+            this.proxyPort = proxyPort;
+            this.proxyHost = new HttpHost(proxyAddress, proxyPort);
+            this.proxyUser = proxyUser;
+            this.proxyPassword = proxyPassword;
+        }
         this.reconnectOnDisconnection = reconnectOnDisconnection;
         this.heartbeat = heartbeat != 0 ? unit.toMillis(heartbeat) : DEFAULT_HEARTBEAT_IN_MILLIS;
-        this.webSocketContainerProvider = webSocketContainerProvider != null ? webSocketContainerProvider : new DefaultWebSocketContainerProvider(proxyAddress, proxyPort, proxyUser, proxyPassword);
-        this.proxyUser = proxyUser;
-        this.proxyPassword = proxyPassword;
+        this.webSocketContainerProvider = webSocketContainerProvider != null ? webSocketContainerProvider : new DefaultWebSocketContainerProvider(this.proxyAddress, this.proxyPort, this.proxyUser, this.proxyPassword);
         addInternalListeners();
     }
 


### PR DESCRIPTION
Useful for cases where proxy presence is not known
 in advance (e.g command tools).
Prior to this, 'IllegalArgumentException: Host name may not be null'
 was thrown by HttpHost(containsNoBlanks), preventing to use
 the builder when no proxy hostname is set.