### PR TITLE
Email casing

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/AbstractSlackSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/AbstractSlackSessionImpl.java
@@ -131,7 +131,7 @@ abstract class AbstractSlackSessionImpl implements SlackSession
     {
         for (SlackUser user : users.values())
         {
-            if (userMail.equals(user.getUserMail()))
+            if (userMail.equalsIgnoreCase(user.getUserMail()))
             {
                 return user;
             }


### PR DESCRIPTION
Near all email addresses are case insensitive. It'd make more sense to accept results with different casings