### PR TITLE
No args constructors for slack messaging model

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackAction.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackAction.java
@@ -82,6 +82,10 @@ public class SlackAction {
             this.dismissText = dismissText;
         }
 
+        public SlackConfirmation() {
+
+        }
+
         public String getTitle() {
             return title;
         }

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackFile.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackFile.java
@@ -28,7 +28,7 @@ public class SlackFile {
     private String comment;
     
     public SlackFile() {
-        super();
+
     }
 
     public String getId() {

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackPreparedMessage.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/SlackPreparedMessage.java
@@ -6,12 +6,12 @@ import java.util.Arrays;
 import java.util.List;
 
 public class SlackPreparedMessage {
-    private final String message;
-    private final boolean unfurl;
-    private final boolean linkNames;
-    private final SlackAttachment[] attachments;
-    private final String threadTimestamp;
-    private final boolean replyBroadcast;
+    private String message;
+    private boolean unfurl;
+    private boolean linkNames;
+    private SlackAttachment[] attachments;
+    private String threadTimestamp;
+    private boolean replyBroadcast;
 
     private SlackPreparedMessage(String message, boolean unfurl, boolean linkNames, SlackAttachment[] attachments, String threadTimestamp, boolean replyBroadcast) {
         this.message = message;
@@ -20,6 +20,10 @@ public class SlackPreparedMessage {
         this.attachments = attachments;
         this.threadTimestamp = threadTimestamp;
         this.replyBroadcast = replyBroadcast;
+    }
+
+    public SlackPreparedMessage(){
+
     }
 
     public String getMessage() {


### PR DESCRIPTION
Without no args constructors it's impossible to use auto mapping between DTO and model with tools such as mapstruct