### PR TITLE
Change log level of unknown event occurrence from WARN to DEBUG

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -236,7 +236,7 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
                     dispatchImpl((UserTyping) event, userTypingListener);
                     break;
                 default:
-                    LOGGER.warn("event of type " + event.getEventType() + " not handled: " + ((UnknownEvent)event).getJsonPayload());
+                    LOGGER.debug("event of type " + event.getEventType() + " not handled: " + ((UnknownEvent)event).getJsonPayload());
             }
         }
 


### PR DESCRIPTION
We're frequently seeing a lot of WARN messages in the logs about unknown event types being ignored. It would be nice to have this type of message logged at the DEBUG level so it can easily be filtered out from the logs.