### PR TITLE
Fix for 235 and maybe 242 + NPE fix for accessing userId in FileComment subtypes.

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONMessageParser.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackJSONMessageParser.java
@@ -202,9 +202,9 @@ class SlackJSONMessageParser {
 	private static SlackMessagePosted parseMessagePublished(JsonObject obj, SlackChannel channel, String ts, SlackSession slackSession) {
 		String text = GsonHelper.getStringOrNull(obj.get("text"));
 		String subtype = GsonHelper.getStringOrNull(obj.get("subtype"));
-
 		String userId = null;
-		if (subtype.equals("file_comment")) {
+		//sloppy fix for finding userId inside File_comment subtype.
+		if (subtype !=null && subtype.equals("file_comment")) {
 			userId = GsonHelper.getStringOrNull(obj.get("comment").getAsJsonObject().get("user"));
 		} else {
 			userId = GsonHelper.getStringOrNull(obj.get("user"));

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -235,6 +235,7 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
 				dispatchImpl((UserTyping) event, userTypingListener);
 				break;
 			default:
+				//sloppy fix for ClassCastException from ? to UnknownEvent Error.
 				if (event instanceof UnknownEvent) {
 					LOGGER.warn("event of type " + event.getEventType() + " not handled: " + ((UnknownEvent) event).getJsonPayload());
 				} else {


### PR DESCRIPTION
maybe fixes : #242 
fixes: #235 

not in a nice way, however does the trick.
Also fixed an NPE when trying to access userId inside a FileComment, which ends up with NPE.