### PR TITLE
functionality to optionally override the default slack api url

### DIFF
--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackSessionFactory.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackSessionFactory.java
@@ -9,7 +9,7 @@ import com.ullink.slack.simpleslackapi.WebSocketContainerProvider;
 public class SlackSessionFactory {
     public static SlackSession createWebSocketSlackSession(String authToken)
     {
-    	return new SlackWebSocketSessionImpl(null,authToken, true, true, 0, null);
+    	return new SlackWebSocketSessionImpl(null, authToken, null, true, true, 0, null);
     }
 
     public static SlackSessionFactoryBuilder getSlackSessionBuilder(String authToken) {
@@ -19,6 +19,7 @@ public class SlackSessionFactory {
     public static class SlackSessionFactoryBuilder {
 
         private String authToken;
+        private String slackBaseApi;
         private Proxy.Type proxyType;
         private String proxyAddress;
         private int proxyPort;
@@ -34,6 +35,11 @@ public class SlackSessionFactory {
             this.authToken = authToken;
         }
 
+        public SlackSessionFactoryBuilder withBaseApiUrl(String slackBaseApi) {
+        	this.slackBaseApi = slackBaseApi;
+        	return this;
+        }
+        
         public SlackSessionFactoryBuilder withProxy(Proxy.Type proxyType, String proxyAddress, int proxyPort) {
             this.proxyType = proxyType;
             this.proxyAddress = proxyAddress;
@@ -72,7 +78,7 @@ public class SlackSessionFactory {
         }
 
         public SlackSession build() {
-            return new SlackWebSocketSessionImpl(provider, authToken, proxyType, proxyAddress, proxyPort, proxyUser, proxyPassword, autoreconnection, rateLimitSupport, heartbeat, unit);
+            return new SlackWebSocketSessionImpl(provider, authToken, slackBaseApi, proxyType, proxyAddress, proxyPort, proxyUser, proxyPassword, autoreconnection, rateLimitSupport, heartbeat, unit);
         }
     }
 }

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -105,8 +105,6 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
 
     private static final Logger               LOGGER                     = LoggerFactory.getLogger(SlackWebSocketSessionImpl.class);
 
-    //private static final String               SLACK_HTTPS_AUTH_URL       = "https://slack.com/api/rtm.start?token=";
-
     private  static final int                 DEFAULT_HEARTBEAT_IN_MILLIS = 30000;
 
     private volatile Session                  websocketSession;
@@ -858,7 +856,6 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
         try
         {
 	        URIBuilder uriBuilder = new URIBuilder(slackApiBase+command);
-	        //uriBuilder.setScheme(SLACK_API_SCHEME).setHost(SLACK_API_HOST).setPath(SLACK_API_PATH+"/"+command);
 	        
 	        for (Map.Entry<String, String> arg : params.entrySet())
 	        {

--- a/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackWebSocketSessionImpl.java
+++ b/sources/src/test/java/com/ullink/slack/simpleslackapi/impl/TestSlackWebSocketSessionImpl.java
@@ -12,8 +12,7 @@ public class TestSlackWebSocketSessionImpl {
 
   @Test(expected = IllegalArgumentException.class)
   public void testSendMessageWithNullChanel(@Mocked WebSocketContainerProvider provider) throws Exception{
-    SlackWebSocketSessionImpl webSocketSession = new SlackWebSocketSessionImpl(provider,
-        "", false, false, 42L, TimeUnit.MILLISECONDS);
+    SlackWebSocketSessionImpl webSocketSession = new SlackWebSocketSessionImpl(provider, "", null, false, false, 42L, TimeUnit.MILLISECONDS);
     try {
       webSocketSession.sendMessage(null, "");
     } catch (NullPointerException e) {


### PR DESCRIPTION
Needed for when slack.com is blocked but specific workspaces are not. For example, https://[myworkspace].slack.com/api/ can be used instead of the default https://slack.com/api/  

I also cleaned up some String literals of the api path that didn't use the constants